### PR TITLE
Hybridization of SMILESEncoderDecoder for Model Sharing.

### DIFF
--- a/moleculegen/base.py
+++ b/moleculegen/base.py
@@ -51,7 +51,7 @@ class Token:
 
     # Subcompounds.
     AGGREGATE = frozenset([
-        '[nH]', '[C@H]', '[C@@H]', '(=O)', '@@'
+        '[nH]', '[C@H]', '[C@@H]', '@@'
     ])
 
     # Special tokens not presented in the SMILES vocabulary.

--- a/moleculegen/data/sampler.py
+++ b/moleculegen/data/sampler.py
@@ -32,7 +32,7 @@ from typing import (
 import mxnet as mx
 from mxnet import gluon
 
-from ..base import StateInitializerMixin, Token
+from ..base import StateInitializerMixin
 from .vocabulary import SMILESVocabulary
 
 
@@ -156,8 +156,8 @@ class SMILESBatchColumnSampler(StateInitializerMixin):
 
     Parameters
     ----------
-    vocabulary : SMILESVocabulary
-        The vocabulary of the original data corpus.
+    corpus : list of list of int
+        The original data corpus loaded from a vocabulary.
     batch_size : int
         The number of samples to generate.
     n_steps : int
@@ -167,7 +167,7 @@ class SMILESBatchColumnSampler(StateInitializerMixin):
 
     Attributes
     ----------
-    vocabulary : SMILESVocabulary
+    corpus : list of list of int
     batch_size : int
     n_steps : int
 
@@ -184,7 +184,7 @@ class SMILESBatchColumnSampler(StateInitializerMixin):
     >>> with TempSMILESFile(smiles_strings=smiles_strings) as temp_fh:
     ...     dataset = SMILESDataset(temp_fh.file_handler.name)
     >>> vocabulary = SMILESVocabulary(dataset, need_corpus=True)
-    >>> sampler = SMILESBatchColumnSampler(vocabulary, 2, 20, shuffle=False)
+    >>> sampler = SMILESBatchColumnSampler(vocabulary.corpus, 2, 20, shuffle=False)
     >>> print('Input batch samples:')
     >>> for i, batch in enumerate(sampler, start=1):
     ...     print(f'Batch #{i}')
@@ -247,26 +247,26 @@ class SMILESBatchColumnSampler(StateInitializerMixin):
 
     def __init__(
             self,
-            vocabulary: SMILESVocabulary,
+            corpus: List[List[int]],
             batch_size: int,
             n_steps: int,
             shuffle: bool = True,
     ):
-        self._vocabulary = vocabulary
+        self._corpus = corpus
         self._shuffle = shuffle
 
         self.batch_size = batch_size
         self.n_steps = n_steps
 
     @property
-    def vocabulary(self) -> SMILESVocabulary:
+    def corpus(self) -> List[List[int]]:
         """The corpus of the original data set.
 
         Returns
         -------
-        vocabulary : SMILESVocabulary
+        corpus : list of list of int
         """
-        return self._vocabulary
+        return self._corpus
 
     @property
     def batch_size(self) -> int:
@@ -344,16 +344,16 @@ class SMILESBatchColumnSampler(StateInitializerMixin):
             valid lengths.
         """
         if self._shuffle:
-            random.shuffle(self._vocabulary.corpus)
+            random.shuffle(self._corpus)
 
         n_batches = (
-            len(self._vocabulary.corpus) // self.batch_size
+            len(self._corpus) // self.batch_size
             * self.batch_size
         )
 
         for i_batch in range(0, n_batches, self.batch_size):
             curr_slice = slice(i_batch, i_batch + self.batch_size)
-            batch = self._pad(self._vocabulary.corpus[curr_slice])
+            batch = self._pad(self._corpus[curr_slice])
 
             yield from self._iter_steps(batch)
 
@@ -399,7 +399,7 @@ class SMILESBatchColumnSampler(StateInitializerMixin):
 
             return mx.np.array(lengths, dtype=int)
 
-        pad_token_idx: int = self._vocabulary[Token.PAD]
+        pad_token_idx = SMILESVocabulary.PAD_ID
 
         inputs, outputs = batch[:, :-1], batch[:, 1:]
 
@@ -445,7 +445,7 @@ class SMILESBatchColumnSampler(StateInitializerMixin):
         # (batch[:, :-1], batch[:, 1:]).
         max_len += 1
 
-        pad_token_idx: int = self._vocabulary[Token.PAD]
+        pad_token_idx = SMILESVocabulary.PAD_ID
         new_items_list: List[List[int]] = []
 
         for item_list in item_lists:
@@ -534,7 +534,7 @@ class SMILESBatchSampler(gluon.data.BatchSampler, StateInitializerMixin):
     >>> with TempSMILESFile(smiles_strings=smiles_strings) as temp_fh:
     ...     dataset = SMILESDataset(temp_fh.file_handler.name)
     >>> vocabulary = SMILESVocabulary(dataset, need_corpus=True)
-    >>> sampler = SMILESConsecutiveSampler(vocabulary, 20, shuffle=False)
+    >>> sampler = SMILESConsecutiveSampler(vocabulary.corpus, 20, shuffle=False)
     >>> batch_sampler = SMILESBatchSampler(sampler, 2)
     >>> for batch_i, batch in enumerate(batch_sampler, start=1):
     ...     print(f'Batch {batch_i}:')
@@ -610,8 +610,8 @@ class SMILESConsecutiveSampler(gluon.data.Sampler):
 
     Parameters
     ----------
-    vocabulary : SMILESVocabulary
-        The SMILES vocabulary containing the loaded corpus.
+    corpus : list of list of int
+        The original data corpus loaded from a vocabulary.
     n_steps : int, default None
         The length of a substring.
         If None, it equals to the maximum string length in the corpus minus 1.
@@ -636,7 +636,7 @@ class SMILESConsecutiveSampler(gluon.data.Sampler):
     >>> with TempSMILESFile(smiles_strings=smiles_string) as temp_fh:
     ...     dataset = SMILESDataset(temp_fh.file_handler.name)
     >>> vocabulary = SMILESVocabulary(dataset, need_corpus=True)
-    >>> sampler = SMILESConsecutiveSampler(vocabulary, n_steps=20)
+    >>> sampler = SMILESConsecutiveSampler(vocabulary.corpus, n_steps=20)
     >>> len(sampler)
     2
     >>> for sample in sampler:
@@ -659,15 +659,15 @@ class SMILESConsecutiveSampler(gluon.data.Sampler):
 
     def __init__(
             self,
-            vocabulary: SMILESVocabulary,
+            corpus: List[List[int]],
             n_steps: Optional[int] = None,
             shuffle: bool = True,
             *,
             sample_type: str = 'sample',
     ):
-        self._vocabulary = vocabulary
+        self._corpus = corpus
         self._shuffle = shuffle
-        self._n_steps = n_steps or max(map(len, self._vocabulary.corpus))
+        self._n_steps = n_steps or max(map(len, self._corpus))
 
         if sample_type == 'sample':
             self._sample_type = lambda inputs, outputs, valid_length: \
@@ -700,10 +700,10 @@ class SMILESConsecutiveSampler(gluon.data.Sampler):
             Input-output sequences.
         """
         if self._shuffle:
-            random.shuffle(self._vocabulary.corpus)
+            random.shuffle(self._corpus)
 
         # Iterate over the corpus of SMILES token indices.
-        for tokens in self._vocabulary.corpus:
+        for tokens in self._corpus:
             step_i = 0  # Starting index of a subsequence.
             step_len = step_i + self._n_steps  # Ending index.
 
@@ -723,7 +723,7 @@ class SMILESConsecutiveSampler(gluon.data.Sampler):
             remainder_len = step_len - len(tokens) + 1
             if remainder_len > 0 and remainder_len != self._n_steps:
                 # fill the lacking tokens with Token.PAD index.
-                pad = [self._vocabulary[Token.PAD]]
+                pad = [SMILESVocabulary.PAD_ID]
 
                 yield self._sample_type(
                     tokens[step_i: step_len] + pad*(remainder_len-1),

--- a/moleculegen/estimation/__init__.py
+++ b/moleculegen/estimation/__init__.py
@@ -3,13 +3,23 @@ Create, train, evaluate, and fine-tune generative models.
 
 Classes
 -------
+SMILESEncoderDecoderABC
+    An ABC for a generative recurrent neural network to encode-decode SMILES strings.
 SMILESEncoderDecoder
     A generative recurrent neural network to encode-decode SMILES strings.
+SMILESEncoderDecoderFineTuner
+    The fine-tuner of SMILESEncoderDecoder model.
 """
 
 __all__ = (
     'SMILESEncoderDecoder',
+    'SMILESEncoderDecoderABC',
+    'SMILESEncoderDecoderFineTuner',
 )
 
 
-from .model import SMILESEncoderDecoder
+from .base import SMILESEncoderDecoderABC
+from .model import (
+    SMILESEncoderDecoder,
+    SMILESEncoderDecoderFineTuner,
+)

--- a/moleculegen/estimation/_gluon_common.py
+++ b/moleculegen/estimation/_gluon_common.py
@@ -4,6 +4,7 @@ Gluon objects and sequential models used in the subpackage.
 
 from typing import Dict
 
+import mxnet as mx
 from mxnet import gluon
 
 
@@ -14,19 +15,33 @@ RNN_MAP: Dict[str, type] = {
     'gru': gluon.rnn.GRU,
 }
 
+INIT_MAP: Dict[str, mx.init.Initializer] = {
+    'normal': mx.init.Normal(),
+    'orthogonal': mx.init.Orthogonal(),
+    'uniform': mx.init.Uniform(),
+    'xavier': mx.init.Xavier(),
+}
+
+CTX_MAP: Dict[str, mx.context.Context] = {
+    'cpu': mx.context.cpu(),
+    'gpu': mx.context.gpu(),
+}
+
 
 def dropout_mlp(
+        *,
         n_layers: int,
         n_units: int,
         activation: str,
         output_dim: int,
         dtype: str,
         dropout: float,
+        prefix: str,
         **kwargs,
 ) -> gluon.Block:
     """A dropout-regularized MLP built with mxnet.gluon.nn.HybridSequential.
     """
-    net = gluon.nn.HybridSequential()
+    net = gluon.nn.HybridSequential(prefix=prefix)
 
     for _ in range(n_layers-1):
         net.add(gluon.nn.Dropout(dropout))
@@ -48,11 +63,13 @@ def dropout_mlp(
 
 
 def mlp(
+        *,
         n_layers: int,
         n_units: int,
         activation: str,
         output_dim: int,
         dtype: str,
+        prefix: str,
         **kwargs,
 ) -> gluon.Block:
     """A single dense layer or an MLP built with mxnet.gluon.nn.HybridSequential.
@@ -61,12 +78,13 @@ def mlp(
         units=output_dim,
         dtype=dtype,
         flatten=False,
+        prefix=prefix if n_layers == 1 else None,
     )
 
     if n_layers == 1:
         return output_dense
 
-    net = gluon.nn.HybridSequential()
+    net = gluon.nn.HybridSequential(prefix=prefix)
 
     for _ in range(n_layers-1):
         net.add(gluon.nn.Dense(

--- a/moleculegen/estimation/_gluon_common.py
+++ b/moleculegen/estimation/_gluon_common.py
@@ -24,9 +24,9 @@ def dropout_mlp(
         dropout: float,
         **kwargs,
 ) -> gluon.Block:
-    """A dropout-regularized MLP built with mxnet.gluon.nn.Sequential.
+    """A dropout-regularized MLP built with mxnet.gluon.nn.HybridSequential.
     """
-    net = gluon.nn.Sequential()
+    net = gluon.nn.HybridSequential()
 
     for _ in range(n_layers-1):
         net.add(gluon.nn.Dropout(dropout))
@@ -55,7 +55,7 @@ def mlp(
         dtype: str,
         **kwargs,
 ) -> gluon.Block:
-    """A single dense layer or an MLP built with mxnet.gluon.nn.Sequential.
+    """A single dense layer or an MLP built with mxnet.gluon.nn.HybridSequential.
     """
     output_dense = gluon.nn.Dense(
         units=output_dim,
@@ -66,7 +66,7 @@ def mlp(
     if n_layers == 1:
         return output_dense
 
-    net = gluon.nn.Sequential()
+    net = gluon.nn.HybridSequential()
 
     for _ in range(n_layers-1):
         net.add(gluon.nn.Dense(

--- a/moleculegen/estimation/base.py
+++ b/moleculegen/estimation/base.py
@@ -1,0 +1,232 @@
+"""
+The base class for generative language models.
+
+Classes
+-------
+SMILESEncoderDecoderABC
+    An ABC for a generative recurrent neural network to encode-decode SMILES strings.
+"""
+
+__all__ = (
+    'SMILESEncoderDecoderABC',
+)
+
+
+import abc
+from typing import Callable, List, Optional, Sequence, Tuple
+
+import mxnet as mx
+from mxnet import autograd, gluon
+
+from ..callback.base import Callback
+from ..data.sampler import BatchSampler
+from ..evaluation.loss import get_mask_for_loss
+
+
+class SMILESEncoderDecoderABC(gluon.HybridBlock, metaclass=abc.ABCMeta):
+    """An ABC for a generative recurrent neural network to encode-decode SMILES strings.
+
+    When subclassing, implement abstract properties `embedding`, `encoder`, and
+    `decoder`.
+
+    Parameters
+    ----------
+    ctx : mxnet.context.Context, default mxnet.context.cpu()
+        CPU or GPU.
+    prefix : str, default None
+    params : mxnet.gluon.ParameterDict, default None
+    """
+
+    def __init__(
+            self,
+            *,
+            ctx: mx.context.Context = mx.context.gpu(),
+            prefix: Optional[str] = None,
+            params: Optional[gluon.ParameterDict] = None,
+    ):
+        super().__init__(prefix=prefix, params=params)
+
+        self.__ctx = ctx
+
+    @property
+    @abc.abstractmethod
+    def embedding(self):
+        """Return the embedding layer."""
+
+    @property
+    @abc.abstractmethod
+    def encoder(self):
+        """Return the RNN encoder."""
+
+    @property
+    @abc.abstractmethod
+    def decoder(self):
+        """Return the Feed-Forward NN decoder."""
+
+    @property
+    def ctx(self) -> mx.context.Context:
+        """Return the model's context.
+        """
+        return self.__ctx
+
+    @ctx.setter
+    def ctx(self, ctx: mx.context.Context):
+        """Set the model's context and reset the parameters' context.
+        """
+        if ctx != self.__ctx:
+            self.collect_params().reset_ctx(ctx)
+            self.__ctx = ctx
+
+    def begin_state(
+            self,
+            batch_size: int = 0,
+            func: Callable[..., mx.nd.NDArray] = mx.nd.zeros,
+            **func_kwargs,
+    ) -> List[mx.np.ndarray]:
+        """Return initial hidden states of a model.
+
+        Parameters
+        ----------
+        batch_size : int, default 0
+            Batch size.
+        func : callable, any -> mxnet.nd.NDArray, default mxnet.nd.zeros
+            The state initializer function.
+        **func_kwargs
+            Additional arguments for RNN layer's `begin_state` method
+            excluding an mxnet context (we explicitly pass the model's ctx).
+
+        Returns
+        -------
+        states : list of mxnet.np.ndarray
+            The list of initial hidden states.
+        """
+        return self.encoder.begin_state(
+            batch_size=batch_size, func=func, ctx=self.__ctx, **func_kwargs)
+
+    # noinspection PyMethodOverriding
+    def hybrid_forward(
+            self,
+            module,
+            inputs: mx.np.ndarray,
+            states: List[mx.np.ndarray],
+    ) -> Tuple[mx.np.ndarray, List[mx.np.ndarray]]:
+        """Run forward computation.
+
+        Parameters
+        ----------
+        module : mxnet.ndarray or mxnet.symbol
+            We ignore the model.
+        inputs : mxnet.np.ndarray,
+                shape = (batch size, time steps)
+            Input samples.
+        states : list of mxnet.np.ndarray,
+                shape = (rnn layers, batch size, rnn units)
+            Hidden states.
+
+        Returns
+        -------
+        outputs : mxnet.np.ndarray,
+                shape = (batch size, time steps, vocabulary dimension)
+            The decoded outputs.
+        states : list of mxnet.np.ndarray,
+                shape = (rnn layers, batch size, rnn units)
+            The updated hidden states.
+        """
+        inputs = self.embedding(inputs.T)
+        outputs, states = self.encoder(inputs, states)
+        outputs = self.decoder(outputs).swapaxes(0, 1)
+
+        return outputs, states
+
+    def fit(
+            self,
+            batch_sampler: BatchSampler,
+            optimizer: mx.optimizer.Optimizer,
+            loss_fn: gluon.loss.Loss,
+            n_epochs: int = 1,
+            callbacks: Optional[Sequence[Callback]] = None,
+    ):
+        """Train the model for `n_epochs` number of epochs. Optionally call `callbacks`
+        to monitor training progress.
+
+        Parameters
+        ----------
+        batch_sampler : BatchSampler
+            The dataloader to sample mini-batches.
+        optimizer : mxnet.optimizer.Optimizer
+            An mxnet optimizer.
+        loss_fn : mxnet.gluon.loss.Loss
+            A gluon loss functor.
+        n_epochs : int, default 1
+            The number of epochs to train.
+        callbacks : sequence of Callback, default None
+            The callbacks to run during training.
+        """
+        # The named arguments required by callbacks on epoch/batch calls.
+        init_params = {
+            # Constant parameters.
+            'batch_sampler': batch_sampler,
+            'optimizer': optimizer,
+            'loss_fn': loss_fn,
+            'n_epochs': n_epochs,
+            # Changeable parameters.
+            'model': self,
+            'epoch': 0,
+        }
+        # The named arguments required by callbacks on batch calls.
+        train_params = dict.fromkeys([
+            'batch_no', 'batch', 'loss', 'predictions', 'outputs'
+        ])
+        callbacks = callbacks or []
+
+        try:
+            self.hybridize()
+
+            trainer = gluon.Trainer(self.collect_params(), optimizer)
+            state_func: Callable = batch_sampler.init_state_func()
+
+            for epoch in range(1, n_epochs + 1):
+
+                init_params['epoch'] = epoch
+                for callback in callbacks:
+                    callback.on_epoch_begin(**init_params)
+
+                states: Optional[List[mx.np.ndarray]] = None
+
+                for batch_no, batch in enumerate(batch_sampler, start=1):
+
+                    batch = batch.as_in_ctx(self.__ctx)
+                    states = batch_sampler.init_states(
+                        model=self,
+                        mini_batch=batch,
+                        states=states,
+                        init_state_func=state_func,
+                    )
+
+                    train_params['batch_no'] = batch_no
+                    train_params['batch'] = batch
+                    for callback in callbacks:
+                        callback.on_batch_begin(**init_params, **train_params)
+
+                    with autograd.record():
+                        predictions, states = self.forward(batch.inputs, states)
+                        weights = get_mask_for_loss(batch.shape, batch.valid_lengths)
+                        loss = loss_fn(predictions, batch.outputs, weights)
+
+                    loss.backward()
+                    trainer.step(batch.valid_lengths.sum())
+
+                    train_params['loss'] = loss
+                    train_params['predictions'] = predictions
+                    train_params['outputs'] = batch.outputs
+                    for callback in callbacks:
+                        callback.on_batch_end(**init_params, **train_params)
+
+                init_params['model'] = self
+                for callback in callbacks:
+                    callback.on_epoch_end(**init_params, **train_params)
+
+        except KeyboardInterrupt:
+            init_params['model'] = self
+            for callback in callbacks:
+                callback.on_keyboard_interrupt(**init_params)

--- a/moleculegen/estimation/model.py
+++ b/moleculegen/estimation/model.py
@@ -5,26 +5,27 @@ Classes
 -------
 SMILESEncoderDecoder
     A generative recurrent neural network to encode-decode SMILES strings.
+SMILESEncoderDecoderFineTuner
+    The fine-tuner of SMILESEncoderDecoder model.
 """
 
 __all__ = (
     'SMILESEncoderDecoder',
+    'SMILESEncoderDecoderFineTuner',
 )
 
 import json
-from typing import Callable, List, Optional, Sequence, Tuple, Union
+from typing import Optional, Union
 
 import mxnet as mx
-from mxnet import autograd, gluon
+from mxnet import gluon
 
 from . import _gluon_common
-from ..callback.base import Callback
-from ..data.sampler import BatchSampler
+from .base import SMILESEncoderDecoderABC
 from ..description.common import OneHotEncoder
-from ..evaluation.loss import get_mask_for_loss
 
 
-class SMILESEncoderDecoder(gluon.HybridBlock):
+class SMILESEncoderDecoder(SMILESEncoderDecoderABC):
     """A generative recurrent neural network to encode-decode SMILES strings.
 
     Parameters
@@ -145,7 +146,7 @@ class SMILESEncoderDecoder(gluon.HybridBlock):
             )
 
         # Initialize mxnet.gluon.Block parameters.
-        super().__init__(prefix=prefix, params=params)
+        super().__init__(ctx=ctx, prefix=prefix, params=params)
 
         with self.name_scope():
             # Define (and initialize) an embedding layer.
@@ -188,23 +189,6 @@ class SMILESEncoderDecoder(gluon.HybridBlock):
             )
             if initialize:
                 self._decoder.initialize(init=dense_init, ctx=ctx)
-
-        # Set the model's context.
-        self.__ctx = ctx
-
-    @property
-    def ctx(self) -> mx.context.Context:
-        """Return the model's context.
-        """
-        return self.__ctx
-
-    @ctx.setter
-    def ctx(self, ctx: mx.context.Context):
-        """Set the model's context and reset the parameters' context.
-        """
-        if ctx != self.__ctx:
-            self.collect_params().reset_ctx(ctx)
-            self.__ctx = ctx
 
     @property
     def embedding(self) -> Union[OneHotEncoder, gluon.nn.Embedding]:
@@ -291,156 +275,107 @@ class SMILESEncoderDecoder(gluon.HybridBlock):
 
         return model
 
-    def begin_state(
+
+class SMILESEncoderDecoderFineTuner(SMILESEncoderDecoderABC):
+    """The fine-tuner of SMILESEncoderDecoder model. Loads embedding and encoder blocks,
+    and trains a new decoder block.
+
+    Parameters
+    ----------
+    model : SMILESEncoderDecoder
+        An encoder-decoder model to fine-tune.
+    output_dim : int
+        The number of output neurons.
+    initialize : bool, default True
+        Whether to initialize decoder's parameters.
+    n_dense_layers : int, default 1
+        The number of dense layers.
+    n_dense_units : int, default 128
+        The number of neurons in each dense layer.
+    dense_activation : str, default 'relu'
+        The activation function in a dense layer.
+    dense_dropout : float, default 0.0
+        The dropout rate of a dense layer.
+    dense_init : str or mxnet.init.Initializer,
+            default mxnet.init.Xavier()
+        The parameter initializer of a dense layer.
+    dense_prefix : str, default 'decoder_'
+        The prefix of a decoder block.
+    dtype : str, default 'float32'
+        Data type.
+    ctx : mxnet.context.Context, default mxnet.context.cpu()
+        CPU or GPU.
+
+    prefix : str, default None
+    params : mxnet.gluon.ParameterDict, default None
+
+    Attributes
+    ----------
+    ctx : mxnet.context.Context
+        The model's context.
+    embedding : OneHotEncoder or mxnet.gluon.nn.Embedding
+        An embedding layer.
+    encoder : mxnet.gluon.rnn.RNN or mxnet.gluon.rnn.LSTM
+            or mxnet.gluon.rnn.GRU
+        An RNN encoder.
+    decoder : mxnet.gluon.nn.Dense or mxnet.gluon.nn.Sequential
+        A Feed-Forward NN decoder.
+    """
+
+    def __init__(
             self,
-            batch_size: int = 0,
-            func: Callable[..., mx.nd.NDArray] = mx.nd.zeros,
-            **func_kwargs,
-    ) -> List[mx.np.ndarray]:
-        """Return initial hidden states of a model.
-
-        Parameters
-        ----------
-        batch_size : int, default 0
-            Batch size.
-        func : callable, any -> mxnet.nd.NDArray, default mxnet.nd.zeros
-            The state initializer function.
-        **func_kwargs
-            Additional arguments for RNN layer's `begin_state` method
-            excluding an mxnet context (we explicitly pass the model's ctx).
-
-        Returns
-        -------
-        states : list of mxnet.np.ndarray
-            The list of initial hidden states.
-        """
-        return self._encoder.begin_state(
-            batch_size=batch_size, func=func, ctx=self.ctx, **func_kwargs)
-
-    # noinspection PyMethodOverriding
-    def hybrid_forward(
-            self,
-            module,
-            inputs: mx.np.ndarray,
-            states: List[mx.np.ndarray],
-    ) -> Tuple[mx.np.ndarray, List[mx.np.ndarray]]:
-        """Run forward computation.
-
-        Parameters
-        ----------
-        module : mxnet.ndarray or mxnet.symbol
-            We ignore the model.
-        inputs : mxnet.np.ndarray,
-                shape = (batch size, time steps)
-            Input samples.
-        states : list of mxnet.np.ndarray,
-                shape = (rnn layers, batch size, rnn units)
-            Hidden states.
-
-        Returns
-        -------
-        outputs : mxnet.np.ndarray,
-                shape = (batch size, time steps, vocabulary dimension)
-            The decoded outputs.
-        states : list of mxnet.np.ndarray,
-                shape = (rnn layers, batch size, rnn units)
-            The updated hidden states.
-        """
-        inputs = self._embedding(inputs.T)
-        outputs, states = self._encoder(inputs, states)
-        outputs = self._decoder(outputs).swapaxes(0, 1)
-
-        return outputs, states
-
-    def fit(
-            self,
-            batch_sampler: BatchSampler,
-            optimizer: mx.optimizer.Optimizer,
-            loss_fn: gluon.loss.Loss,
-            n_epochs: int = 1,
-            callbacks: Optional[Sequence[Callback]] = None,
+            model: SMILESEncoderDecoder,
+            output_dim: int,
+            initialize: bool = True,
+            n_dense_layers: int = 1,
+            n_dense_units: int = 128,
+            dense_activation: str = 'relu',
+            dense_dropout: float = 0.,
+            dense_init: Optional[Union[str, mx.init.Initializer]] = mx.init.Xavier(),
+            dense_prefix: str = 'fine_tuner_decoder_',
+            dtype: Optional[str] = 'float32',
+            *,
+            ctx: mx.context.Context = mx.context.cpu(),
+            prefix: Optional[str] = None,
+            params: Optional[gluon.ParameterDict] = None,
     ):
-        """Train the model for `n_epochs` number of epochs. Optionally call `callbacks`
-        to monitor training progress.
+        super().__init__(ctx=ctx, prefix=prefix, params=params)
 
-        Parameters
-        ----------
-        batch_sampler : BatchSampler
-            The dataloader to sample mini-batches.
-        optimizer : mxnet.optimizer.Optimizer
-            An mxnet optimizer.
-        loss_fn : mxnet.gluon.loss.Loss
-            A gluon loss functor.
-        n_epochs : int, default 1
-            The number of epochs to train.
-        callbacks : sequence of Callback, default None
-            The callbacks to run during training.
+        model.ctx = self.ctx
+
+        self._embedding = model.embedding
+        self._encoder = model.encoder
+
+        if dense_dropout > 1e-3:
+            mlp_func = _gluon_common.dropout_mlp
+        else:
+            mlp_func = _gluon_common.mlp
+        self._decoder = mlp_func(
+            n_layers=n_dense_layers,
+            n_units=n_dense_units,
+            activation=dense_activation,
+            output_dim=output_dim,
+            dtype=dtype,
+            dropout=dense_dropout,
+            prefix=dense_prefix,
+        )
+        if initialize:
+            self._decoder.initialize(init=dense_init, ctx=self.ctx)
+
+    @property
+    def embedding(self) -> Union[OneHotEncoder, gluon.nn.Embedding]:
+        """Return the embedding layer.
         """
-        # The named arguments required by callbacks on epoch/batch calls.
-        init_params = {
-            # Constant parameters.
-            'batch_sampler': batch_sampler,
-            'optimizer': optimizer,
-            'loss_fn': loss_fn,
-            'n_epochs': n_epochs,
-            # Changeable parameters.
-            'model': self,
-            'epoch': 0,
-        }
-        # The named arguments required by callbacks on batch calls.
-        train_params = dict.fromkeys([
-            'batch_no', 'batch', 'loss', 'predictions', 'outputs'
-        ])
-        callbacks = callbacks or []
+        return self._embedding
 
-        try:
-            self.hybridize()
+    @property
+    def encoder(self) -> Union[gluon.rnn.RNN, gluon.rnn.LSTM, gluon.rnn.GRU]:
+        """Return the RNN encoder.
+        """
+        return self._encoder
 
-            trainer = gluon.Trainer(self.collect_params(), optimizer)
-            state_func: Callable = batch_sampler.init_state_func()
-
-            for epoch in range(1, n_epochs + 1):
-
-                init_params['epoch'] = epoch
-                for callback in callbacks:
-                    callback.on_epoch_begin(**init_params)
-
-                states: Optional[List[mx.np.ndarray]] = None
-
-                for batch_no, batch in enumerate(batch_sampler, start=1):
-
-                    batch = batch.as_in_ctx(self.ctx)
-                    states = batch_sampler.init_states(
-                        model=self,
-                        mini_batch=batch,
-                        states=states,
-                        init_state_func=state_func,
-                    )
-
-                    train_params['batch_no'] = batch_no
-                    train_params['batch'] = batch
-                    for callback in callbacks:
-                        callback.on_batch_begin(**init_params, **train_params)
-
-                    with autograd.record():
-                        predictions, states = self.forward(batch.inputs, states)
-                        weights = get_mask_for_loss(batch.shape, batch.valid_lengths)
-                        loss = loss_fn(predictions, batch.outputs, weights)
-
-                    loss.backward()
-                    trainer.step(batch.valid_lengths.sum())
-
-                    train_params['loss'] = loss
-                    train_params['predictions'] = predictions
-                    train_params['outputs'] = batch.outputs
-                    for callback in callbacks:
-                        callback.on_batch_end(**init_params, **train_params)
-
-                init_params['model'] = self
-                for callback in callbacks:
-                    callback.on_epoch_end(**init_params, **train_params)
-
-        except KeyboardInterrupt:
-            init_params['model'] = self
-            for callback in callbacks:
-                callback.on_keyboard_interrupt(**init_params)
+    @property
+    def decoder(self) -> Union[gluon.nn.Dense, gluon.nn.Sequential]:
+        """Return the Feed-Forward NN decoder.
+        """
+        return self._decoder

--- a/moleculegen/estimation/model.py
+++ b/moleculegen/estimation/model.py
@@ -24,7 +24,7 @@ from ..description.common import OneHotEncoder
 from ..evaluation.loss import get_mask_for_loss
 
 
-class SMILESEncoderDecoder(gluon.Block):
+class SMILESEncoderDecoder(gluon.HybridBlock):
     """A generative recurrent neural network to encode-decode SMILES strings.
 
     Parameters
@@ -239,8 +239,10 @@ class SMILESEncoderDecoder(gluon.Block):
         return self._encoder.begin_state(
             batch_size=batch_size, func=func, ctx=self.ctx, **func_kwargs)
 
-    def forward(
+    # noinspection PyMethodOverriding
+    def hybrid_forward(
             self,
+            module,
             inputs: mx.np.ndarray,
             states: List[mx.np.ndarray],
     ) -> Tuple[mx.np.ndarray, List[mx.np.ndarray]]:
@@ -248,6 +250,8 @@ class SMILESEncoderDecoder(gluon.Block):
 
         Parameters
         ----------
+        module : mxnet.ndarray or mxnet.symbol
+            We ignore the model.
         inputs : mxnet.np.ndarray,
                 shape = (batch size, time steps)
             Input samples.
@@ -312,6 +316,8 @@ class SMILESEncoderDecoder(gluon.Block):
         callbacks = callbacks or []
 
         try:
+            self.hybridize()
+
             trainer = gluon.Trainer(self.collect_params(), optimizer)
             state_func: Callable = batch_sampler.init_state_func()
 

--- a/moleculegen/tests/test_base.py
+++ b/moleculegen/tests/test_base.py
@@ -100,7 +100,7 @@ class TokenTestCase(unittest.TestCase):
         test(['C', 'N', 'C', 'n', 'o', 'Cl', 'C', 'Cl', 'O'])
 
         # Subcompound tokens.
-        test(['N', '[C@H]', '(', 'C', ')', 'C', '(=O)', 'O'])
+        test(['N', '[C@H]', '(', 'C', ')', 'C', '(', '=', 'O', ')', 'O'])
 
 
 if __name__ == '__main__':

--- a/moleculegen/tests/test_data.py
+++ b/moleculegen/tests/test_data.py
@@ -54,7 +54,7 @@ class SMILESBatchColumnSamplerTestCase(unittest.TestCase):
         dataset = SMILESDataset(self.fh.name)
         vocabulary = SMILESVocabulary(dataset=dataset, need_corpus=True)
         self.dataloader = SMILESBatchColumnSampler(
-            vocabulary=vocabulary,
+            corpus=vocabulary.corpus,
             batch_size=2,
             n_steps=4,
             shuffle=True,
@@ -83,7 +83,7 @@ class SMILESConsecutiveSamplerTestCase(unittest.TestCase):
     def test_sampling_with_padding(self):
         smiles_string = Token.tokenize(Token.augment(self.smiles_string))
         n_steps = 20
-        sampler = SMILESConsecutiveSampler(self.vocabulary, n_steps=n_steps)
+        sampler = SMILESConsecutiveSampler(self.vocabulary.corpus, n_steps=n_steps)
 
         step_i = 0
         for sample in sampler:
@@ -108,7 +108,7 @@ class SMILESConsecutiveSamplerTestCase(unittest.TestCase):
     def test_sampling_without_padding(self):
         tokens = Token.tokenize(Token.augment(self.smiles_string))
         n_steps = len(tokens) - 1
-        sampler = SMILESConsecutiveSampler(self.vocabulary, n_steps=n_steps)
+        sampler = SMILESConsecutiveSampler(self.vocabulary.corpus, n_steps=n_steps)
 
         step_i = 0
         for n_samples, sample in enumerate(sampler, start=1):

--- a/moleculegen/tests/test_estimation.py
+++ b/moleculegen/tests/test_estimation.py
@@ -49,16 +49,17 @@ class SMILESEncoderDecoderTestCase(unittest.TestCase):
             dense_dropout=0.0,
             dense_init=mx.init.Xavier(),
             dtype='float32',
+            prefix='model_'
         )
 
     def test_1_params(self):
         param_names = (
-            'embedding0_weight',
+            'model_embedding_weight',
 
-            'lstm0_l0_i2h_weight', 'lstm0_l0_h2h_weight',
-            'lstm0_l0_i2h_bias', 'lstm0_l0_h2h_bias',
+            'model_encoder_l0_i2h_weight', 'model_encoder_l0_h2h_weight',
+            'model_encoder_l0_i2h_bias', 'model_encoder_l0_h2h_bias',
 
-            'dense0_weight', 'dense0_bias',
+            'model_decoder_weight', 'model_decoder_bias',
         )
 
         for actual_p, test_p in zip(param_names, self.model.collect_params()):

--- a/moleculegen/tests/test_estimation.py
+++ b/moleculegen/tests/test_estimation.py
@@ -23,9 +23,9 @@ class SMILESEncoderDecoderTestCase(unittest.TestCase):
         self.fh = temp_file.open()
 
         dataset = SMILESDataset(self.fh.name)
-        vocabulary = SMILESVocabulary(dataset, need_corpus=True)
+        self.vocabulary = SMILESVocabulary(dataset, need_corpus=True)
         self.batch_sampler = SMILESBatchColumnSampler(
-            vocabulary=vocabulary,
+            corpus=self.vocabulary.corpus,
             batch_size=3,
             n_steps=8,
         )
@@ -34,7 +34,7 @@ class SMILESEncoderDecoderTestCase(unittest.TestCase):
         self.n_rnn_units = 32  # Used in output/state shape testing.
 
         self.model = SMILESEncoderDecoder(
-            len(vocabulary),
+            len(self.vocabulary),
             use_one_hot=False,
             embedding_dim=4,
             embedding_init=mx.init.Orthogonal(),
@@ -74,7 +74,7 @@ class SMILESEncoderDecoderTestCase(unittest.TestCase):
             (
                 self.batch_sampler.batch_size,
                 self.batch_sampler.n_steps,
-                len(self.batch_sampler.vocabulary),
+                len(self.vocabulary),
             ),
             outputs.shape,
         )
@@ -92,6 +92,7 @@ class SMILESEncoderDecoderTestCase(unittest.TestCase):
         that training progresses.
         """
         callbacks = [ProgressBar()]
+        # noinspection PyTypeChecker
         self.model.fit(
             batch_sampler=self.batch_sampler,
             optimizer=mx.optimizer.Adam(learning_rate=0.005),


### PR DESCRIPTION
Resolves #21 

- [x] Hybridize `moleculegen.estimation.SMILESEncoderDecoder`.
- [x] Create the fine-tuner initializer loading parameters for a new fine-tuner model and reinitializing its decoder.
- [x] Create a new fine-tuner class accepting a `SMILESEncoderDecoder` instance and reinitializing the decoder. In this case, we can proceed training without need to load weights from a checkpoint. But note that in contrast to the above, the main model will be modified during fine-tuning.