### PR TITLE
New callback 'DescriptorPlotter' and alternative SMILES generators

### DIFF
--- a/moleculegen/callback/__init__.py
+++ b/moleculegen/callback/__init__.py
@@ -16,6 +16,9 @@ EpochMetricScorer
     Calculate and log metrics at the end of every epoch.
 Generator
     Generate, save, and optionally evaluate new compounds.
+PhysChemDescriptorPlotter
+    Project physicochemical descriptors of training and validation data into 2D using
+    sklearn-compatible transformers (e.g. `TSNE` or `PCA`) and plot every chosen epoch.
 ProgressBar
     Print progress bar every epoch of model training.
 """
@@ -27,6 +30,7 @@ __all__ = (
     'EarlyStopping',
     'EpochMetricScorer',
     'Generator',
+    'PhysChemDescriptorPlotter',
     'ProgressBar',
 )
 
@@ -40,5 +44,6 @@ from .callbacks import (
     EarlyStopping,
     EpochMetricScorer,
     Generator,
+    PhysChemDescriptorPlotter,
     ProgressBar,
 )

--- a/moleculegen/callback/callbacks.py
+++ b/moleculegen/callback/callbacks.py
@@ -11,6 +11,9 @@ EpochMetricScorer
     Calculate and log metrics at the end of every epoch.
 Generator
     Generate, save, and optionally evaluate new compounds.
+PhysChemDescriptorPlotter
+    Project physicochemical descriptors of training and validation data into 2D using
+    sklearn-compatible transformers (e.g. `TSNE` or `PCA`) and plot every chosen epoch.
 ProgressBar
     Print progress bar every epoch of model training.
 """
@@ -20,6 +23,7 @@ __all__ = (
     'EarlyStopping',
     'EpochMetricScorer',
     'Generator',
+    'PhysChemDescriptorPlotter',
     'ProgressBar',
 )
 
@@ -33,14 +37,15 @@ import tempfile
 import time
 from typing import Deque, List, Optional, Sequence, Union
 
+import matplotlib.pyplot as plt
 import mxnet as mx
+from rdkit.Chem import MolFromSmiles
 
 from .base import Callback
-from ..base import Token
-from ..data.vocabulary import SMILESVocabulary
-from ..estimation.model import SMILESEncoderDecoder
+from ..description.base import get_descriptors_df
+from ..description.physicochemical import DESCRIPTOR_FUNCTIONS
 from ..evaluation.metric import CompositeMetric, Metric
-from ..generation.greedy_search import GreedySearch
+from ..generation.search import BaseSearch
 
 
 class BatchMetricScorer(Callback):
@@ -99,15 +104,7 @@ class EpochMetricScorer(Callback):
         compounds (e.g. RAC).
     predictor : GreedySearch
         A SMILES string predictor.
-    vocabulary : SMILESVocabulary
-        The vocabulary to encode-decode tokens.
-    prefix : str, default: Token.BOS
-        The prefix of a SMILES string to generate
-    max_length : int, default: 80
-        The maximum number of tokens to generate.
-    temperature : float, default 1.0
-        A sensitivity parameter.
-    n_predictions : int, default 10000
+    n_predictions : int, default 1000
         The number of SMILES strings to generate.
     train_dataset : sequence of str, default None
         A dataset to compare the generated compounds with.
@@ -116,11 +113,7 @@ class EpochMetricScorer(Callback):
     def __init__(
             self,
             metrics: Union[Sequence[Metric], CompositeMetric],
-            predictor: GreedySearch,
-            vocabulary: SMILESVocabulary,
-            prefix: str = Token.BOS,
-            max_length: int = 80,
-            temperature: float = 1.0,
+            predictor: BaseSearch,
             n_predictions: int = 1000,
             train_dataset: Optional[Sequence[str]] = None,
     ):
@@ -130,12 +123,6 @@ class EpochMetricScorer(Callback):
             self.__metrics = metrics
 
         self.__predictor = predictor
-        self.__predictor_kwargs = {
-            'vocabulary': vocabulary,
-            'prefix': prefix,
-            'max_length': max_length,
-            'temperature': temperature,
-        }
         self.__n_predictions = n_predictions
         self.__train_dataset = train_dataset
 
@@ -152,15 +139,8 @@ class EpochMetricScorer(Callback):
         Expected named arguments:
             - model
         """
-        model: SMILESEncoderDecoder = fit_kwargs.get('model')
-
         for _ in range(self.__n_predictions):
-            states = model.begin_state(batch_size=1)
-            smiles = self.__predictor(
-                model=model,
-                states=states,
-                **self.__predictor_kwargs,
-            )
+            smiles = self.__predictor()
             self.__metrics.update(predictions=[smiles], labels=self.__train_dataset)
 
         results = ', '.join(
@@ -447,8 +427,6 @@ class Generator(Callback):
         `filename_epoch_{epoch}.csv`.
     predictor : GreedySearch
         A SMILES string predictor.
-    vocabulary : SMILESVocabulary
-        The vocabulary to encode-decode tokens.
     n_predictions : int, default 1000
         The number of compounds to generate.
     epoch : int, default None
@@ -458,38 +436,33 @@ class Generator(Callback):
         Generate on keyboard interrupt
         (e.g. manual keyboard interrupt or early stopping).
     kwargs : dict, str -> any, default None
-        Additional key-word arguments for `predictor` and `metric`.
+        Additional key-word arguments for `metric`.
     """
 
     def __init__(
             self,
             filename: str,
-            predictor: GreedySearch,
-            vocabulary: SMILESVocabulary,
+            predictor: BaseSearch,
+            n_predictions: int = 1000,
             metric: Optional[Metric] = None,
             epoch: Optional[int] = None,
             on_interrupt: bool = False,
             **kwargs,
     ):
         self.__predictor = predictor
-        self.__vocabulary = vocabulary
+        self.__n_predictions = n_predictions
         self.__filename = filename
         self.__metric = metric
         self.__epoch = epoch
         self.__on_interrupt = on_interrupt
         self.__kwargs = kwargs
 
-    def _generate_and_save(
-            self,
-            model: SMILESEncoderDecoder,
-            epoch: Optional[int],
-    ):
+    def _generate_and_save(self, epoch: Optional[int]):
         """Generate and save predictions. If `metric` is specified, evaluate the
         predictions.
 
         Parameters
         ----------
-        model : SMILESEncoderDecoder
         epoch : int, default None
         """
         def generate() -> str:
@@ -499,15 +472,7 @@ class Generator(Callback):
             -------
             smiles : str
             """
-            states = model.begin_state(batch_size=1)
-            smiles = self.__predictor(
-                model=model,
-                states=states,
-                vocabulary=self.__vocabulary,
-                prefix=self.__kwargs.get('prefix', Token.BOS),
-                temperature=self.__kwargs.get('temperature', 0.65),
-                max_length=self.__kwargs.get('max_length', 80),
-            )
+            smiles = self.__predictor()
             fh.write(f'{smiles}\n')
 
             return smiles
@@ -516,7 +481,7 @@ class Generator(Callback):
         # times and evaluate them;
         if self.__metric is not None:
             def call():
-                for _ in range(self.__kwargs.get('n_predictions')):
+                for _ in range(self.__n_predictions):
                     self.__metric.update(
                         predictions=[generate()],
                         labels=self.__kwargs.get('train_dataset'),
@@ -527,7 +492,7 @@ class Generator(Callback):
         # otherwise, generate and save strings `n_predictions` times.
         else:
             def call():
-                for _ in range(self.__kwargs.get('n_predictions')):
+                for _ in range(self.__n_predictions):
                     generate()
 
         if epoch is not None:
@@ -562,13 +527,11 @@ class Generator(Callback):
         ----------
         Expected named arguments:
             - epoch
-            - model
         """
-        model = fit_kwargs.get('model')
         epoch = fit_kwargs.get('epoch')
 
         if epoch % self.__epoch == 0:
-            self._generate_and_save(model, epoch)
+            self._generate_and_save(epoch)
 
     def on_keyboard_interrupt(self, **fit_kwargs):
         """Optionally launch generation process on (keyboard) interrupt.
@@ -577,10 +540,113 @@ class Generator(Callback):
         ----------
         Expected named arguments:
             - epoch
-            - model
         """
-        model = fit_kwargs.get('model')
         epoch = fit_kwargs.get('epoch')
 
         if self.__on_interrupt:
-            self._generate_and_save(model, epoch)
+            self._generate_and_save(epoch)
+
+
+class PhysChemDescriptorPlotter(Callback):
+    """Project physicochemical descriptors of training and validation data into 2D using
+    sklearn-compatible transformers (e.g. `TSNE` or `PCA`) and plot every chosen epoch.
+
+    Parameters
+    ----------
+    transformer
+        A dimensionality reduction method supporting `fit_transform` and/or `transform`
+        methods.
+    train_data : list of str
+        A training SMILES data.
+    image_file_prefix : str
+        The prefix of saved images (e.g. if prefix is 'descriptors', then files will have
+        names 'descriptors_epoch_1.png', ..., 'descriptors_epoch_N.png').
+    epoch : int, default None
+        If None, plot only after the full training process.
+        If int, plot every `epoch`th epoch.
+    predictor : BaseSearch, default None
+        If not None, generate a validation SMILES data of size equalling to the training
+        data from this predictor.
+        Pass either `predictor` or `valid_data_file_prefix`.
+    valid_data_file_prefix : str, default None
+        If not None, load the validation data from files with names
+        '{valid_data_file_prefix}_epoch_{epoch}.csv'.
+        Pass either `predictor` or `valid_data_file_prefix`.
+    """
+
+    def __init__(
+            self,
+            transformer,
+            train_data: List[str],
+            image_file_prefix: str,
+            epoch: Optional[int] = None,
+            predictor: Optional[BaseSearch] = None,
+            valid_data_file_prefix: Optional[str] = None,
+    ):
+        if predictor is None and valid_data_file_prefix is None:
+            raise ValueError('pass either `predictor` or `valid_data_file_prefix`')
+
+        self._transformer = transformer
+        self._predictor = predictor
+        self._valid_data_file_prefix = valid_data_file_prefix
+        self._image_file_prefix = image_file_prefix
+        self._epoch = epoch
+
+        self._train_data_t = get_descriptors_df(train_data, DESCRIPTOR_FUNCTIONS)
+        self._train_data_t = self._transformer.fit_transform(self._train_data_t)
+
+    def on_epoch_begin(self, **fit_kwargs):
+        n_epochs = fit_kwargs.get('n_epochs')
+
+        if self._epoch is None:
+            self._epoch = n_epochs
+
+    def on_epoch_end(self, **fit_kwargs):
+        """Load or generate a validation SMILES data set, generate descriptors,
+        transform the descriptors into 2D, and save the scatter plot of train vs. valid
+        descriptors projection.
+
+        Parameters
+        ----------
+        Expected named arguments:
+            - epoch
+        """
+
+        def get_valid_data_desc():
+            if hasattr(self._transformer, 'transform'):
+                return self._transformer.transform(valid_data_desc)
+            return self._transformer.fit_transform(valid_data_desc)
+
+        def plot():
+            plt.figure(figsize=(10, 10))
+            plt.title(f'Phys.Chem Descriptors ({self._transformer.__class__.__name__})')
+            plt.scatter(
+                self._train_data_t[:, 0], self._train_data_t[:, 1],
+                label='Training', c='m', edgecolors='k', alpha=0.5,
+            )
+            plt.scatter(
+                valid_data_t[:, 0], valid_data_t[:, 1],
+                label='Generated', c='g', edgecolors='k', alpha=0.85,
+            )
+            plt.legend()
+            plt.savefig(f'{self._image_file_prefix}_epoch_{epoch}.png')
+
+        epoch = fit_kwargs.get('epoch')
+        if epoch % self._epoch == 0:
+
+            if self._valid_data_file_prefix is not None:
+                with open(f'{self._valid_data_file_prefix}_epoch_{epoch}.csv') as fh:
+                    valid_data_desc = get_descriptors_df(
+                        [s for s in fh.readlines() if MolFromSmiles(s) is not None],
+                        DESCRIPTOR_FUNCTIONS,
+                    )
+            else:
+                valid_data_desc = (
+                    self._predictor() for _ in range(self._train_data_t.shape[0])
+                )
+                valid_data_desc = [
+                    s for s in valid_data_desc if MolFromSmiles(s) is not None
+                ]
+
+            valid_data_t = get_valid_data_desc()
+            plot()

--- a/moleculegen/callback/callbacks.py
+++ b/moleculegen/callback/callbacks.py
@@ -102,7 +102,7 @@ class EpochMetricScorer(Callback):
     metrics : CompositeMetric or sequence of Metric
         The metrics to calculate at the end of an epoch on a set of generated
         compounds (e.g. RAC).
-    predictor : GreedySearch
+    predictor : BaseSearch
         A SMILES string predictor.
     n_predictions : int, default 1000
         The number of SMILES strings to generate.
@@ -425,7 +425,7 @@ class Generator(Callback):
         The name of a file to save predictions. If `epoch` is None, then the full file
         name will be `filename.csv`. Otherwise, every file will have the name
         `filename_epoch_{epoch}.csv`.
-    predictor : GreedySearch
+    predictor : BaseSearch
         A SMILES string predictor.
     n_predictions : int, default 1000
         The number of compounds to generate.

--- a/moleculegen/estimation/_gluon_common.py
+++ b/moleculegen/estimation/_gluon_common.py
@@ -47,10 +47,13 @@ def mlp(
         prefix=prefix if n_layers == 1 else None,
     )
 
-    if n_layers == 1:
+    if dropout <= 1e-3 and n_layers == 1:
         return output_dense
 
     net = gluon.nn.HybridSequential(prefix=prefix)
+
+    if dropout > 1e-3:
+        net.add(gluon.nn.Dropout(dropout))
 
     for _ in range(n_layers-1):
         net.add(gluon.nn.Dense(

--- a/moleculegen/generation/__init__.py
+++ b/moleculegen/generation/__init__.py
@@ -3,13 +3,36 @@ Generate SMILES sequences using various search methods.
 
 Classes
 -------
+BaseSearch
+    The base SMILES sampler class.
+
+ArgmaxSearch
+    Generate new SMILES strings using greedy search (argmax) method.
+
+SoftmaxSearch
+    Softmax with a sensitivity parameter followed by sampling from multinomial
+    distribution.
+GumbelSoftmaxSearch
+    Gumbel-Softmax with a sensitivity parameter followed by sampling from multinomial
+    distribution.
+
 GreedySearch
     Generate new SMILES strings using greedy search methods.
 """
 
 __all__ = (
+    'ArgmaxSearch',
+    'BaseSearch',
     'GreedySearch',
+    'GumbelSoftmaxSearch',
+    'SoftmaxSearch',
 )
 
 
 from .greedy_search import GreedySearch
+from .search import (
+    ArgmaxSearch,
+    BaseSearch,
+    GumbelSoftmaxSearch,
+    SoftmaxSearch,
+)

--- a/moleculegen/generation/search.py
+++ b/moleculegen/generation/search.py
@@ -139,7 +139,7 @@ class BaseSearch:
         return self._normalizer
 
     @property
-    def distribution(self) -> Callable[..., mx.np.ndarray]:
+    def distribution(self) -> Callable[..., int]:
         return self._distribution
 
     def _np_token_data(self, token_id: List[int]) -> mx.np.ndarray:

--- a/moleculegen/generation/search.py
+++ b/moleculegen/generation/search.py
@@ -1,0 +1,374 @@
+"""
+SMILES samplers to generate new molecules using various greedy search methods.
+
+Classes
+-------
+BaseSearch
+    The base SMILES sampler class.
+
+ArgmaxSearch
+    Generate new SMILES strings using greedy search (argmax) method.
+
+SoftmaxSearch
+    Softmax with a sensitivity parameter followed by sampling from multinomial
+    distribution.
+GumbelSoftmaxSearch
+    Gumbel-Softmax with a sensitivity parameter followed by sampling from multinomial
+    distribution.
+"""
+
+__all__ = (
+    'ArgmaxSearch',
+    'BaseSearch',
+    'GumbelSoftmaxSearch',
+    'SoftmaxSearch',
+)
+
+
+import functools
+from typing import Callable, List, Optional
+
+import mxnet as mx
+
+from ..base import Token
+from ..data.vocabulary import SMILESVocabulary
+from ..estimation.base import SMILESEncoderDecoderABC
+
+
+class BaseSearch:
+    """The base SMILES sampler class.
+
+    Parameters
+    ----------
+    model : SMILESEncoderDecoderABC
+        A (trained) language model. Generates one token ID in one step.
+    vocabulary : SMILESVocabulary
+        A SMILES vocabulary. Provides id-to-token conversion.
+    prefix : str
+        The prefix of a SMILES string to generate.
+    max_length : int
+        The maximum number of tokens in the SMILES string being generated.
+    state_initializer : callable, any -> mx.nd.NDArray
+        The model's hidden state initializer function (e.g. mx.nd.ones).
+    normalizer : callable, any -> mx.np.ndarray
+        A function that accepts model's outputs (logits) and returns probabilities.
+    distribution : callable, any -> int
+        A function that accepts an ndarray of probabilities and returns the ID
+        of a sampled token.
+    """
+
+    def __init__(
+            self,
+            model: SMILESEncoderDecoderABC,
+            vocabulary: SMILESVocabulary,
+            *,
+            prefix: str,
+            max_length: int,
+            state_initializer: Callable[..., mx.nd.NDArray],
+            normalizer: Callable,
+            distribution: Callable,
+    ):
+        self._model = model
+        self._vocabulary = vocabulary
+        self._normalizer = normalizer
+        self._distribution = distribution
+
+        self.prefix = prefix
+        self.max_length = max_length
+        self.state_initializer = state_initializer
+
+    @property
+    def prefix(self) -> str:
+        return self.__prefix
+
+    @prefix.setter
+    def prefix(self, prefix: str):
+        """Set new `prefix`. Check for validity using moleculegen's available tokens.
+
+        Parameters
+        ----------
+        prefix : str
+            SMILES prefix of length >= 1.
+
+        Raises
+        ------
+        ValueError
+            If there is an invalid token in `prefix`.
+        """
+        all_tokens = Token.get_all_tokens()
+        prefix_tokens: List[str] = Token.tokenize(prefix)
+
+        for token in prefix_tokens:
+            if token not in all_tokens:
+                raise ValueError(f'token {token!r} is invalid')
+        else:
+            self.__prefix = prefix
+
+    @property
+    def max_length(self) -> int:
+        return self.__max_length
+
+    @max_length.setter
+    def max_length(self, max_length: int):
+        """Set new `max_length`. Must be greater than 1.
+
+        Parameters
+        ----------
+        max_length : int
+
+        Raises
+        ------
+        ValueError
+            If `max_length` < 2
+        """
+        if max_length < 2:
+            raise ValueError('max_length must be greater than 1')
+
+        self.__max_length = max_length
+
+    @property
+    def model(self) -> SMILESEncoderDecoderABC:
+        return self._model
+
+    @property
+    def vocabulary(self) -> SMILESVocabulary:
+        return self._vocabulary
+
+    @property
+    def normalizer(self) -> Callable[..., mx.np.ndarray]:
+        return self._normalizer
+
+    @property
+    def distribution(self) -> Callable[..., mx.np.ndarray]:
+        return self._distribution
+
+    def _np_token_data(self, token_id: List[int]) -> mx.np.ndarray:
+        return mx.np.array(token_id, ctx=self._model.ctx).astype(int).reshape(1, 1)
+
+    def __call__(self) -> str:
+        """Generate a SMILES string.
+
+        Returns
+        -------
+        smiles : str
+        """
+        # Initialize hidden states.
+        states = self._model.begin_state(batch_size=1, func=self.state_initializer)
+        # Tokenize sequence correctly.
+        tokens: List[str] = Token.tokenize(self.prefix)
+        # Save predicted token IDs.
+        token_ids: List[int] = [self._vocabulary[tokens[0]]]
+
+        # Update `states` on prefix tokens (no prediction is made).
+        for token in tokens[1:]:
+            token_id = self._np_token_data([token_ids[-1]])
+            _, states = self._model(token_id, states)
+            token_ids.append(self._vocabulary[token])
+
+        # Predict the next token IDs.
+        for n_iter in range(self.max_length):
+            inputs = self._np_token_data([token_ids[-1]])
+            outputs, states = self._model(inputs, states)
+
+            # Normalize outputs to get probabilities (e.g. using softmax).
+            probabilities: mx.np.ndarray = self._normalizer(outputs[0])
+
+            # Sample from a distribution (e.g. multinomial).
+            next_token_id: int = self._distribution(probabilities)
+
+            # Interrupt, if End-of-SMILES token is generated.
+            token: str = self._vocabulary.idx_to_token[next_token_id]
+            if token == Token.EOS:
+                break
+
+            token_ids.append(next_token_id)
+
+        smiles = ''.join(self._vocabulary.idx_to_token[id_] for id_ in token_ids)
+        # Remove special tokens.
+        smiles = Token.crop(smiles)
+
+        return smiles
+
+
+def _identity(data: mx.np.ndarray) -> mx.np.ndarray:
+    return data
+
+
+def _argmax(logits: mx.np.ndarray) -> int:
+    return logits.argmax().item()
+
+
+class ArgmaxSearch(BaseSearch):
+    """Generate new SMILES strings using greedy search (argmax) method. Basically, the
+    strategy is to search for the next token with the highest conditional (logit)
+    probability.
+
+    Parameters
+    ----------
+    model : SMILESEncoderDecoderABC
+        A (trained) language model. Generates one token ID in one step.
+    vocabulary : SMILESVocabulary
+        A SMILES vocabulary. Provides id-to-token conversion.
+    prefix : str
+        The prefix of a SMILES string to generate.
+    max_length : int
+        The maximum number of tokens in the SMILES string being generated.
+    state_initializer : callable, any -> mx.nd.NDArray
+        The model's hidden state initializer function (e.g. mx.nd.ones).
+    """
+
+    def __init__(
+            self,
+            model: SMILESEncoderDecoderABC,
+            vocabulary: SMILESVocabulary,
+            *,
+            prefix: str = Token.BOS,
+            max_length: int = 80,
+            state_initializer: Callable[..., mx.nd.NDArray] = mx.nd.uniform,
+    ):
+        super().__init__(
+            model=model,
+            vocabulary=vocabulary,
+            prefix=prefix,
+            max_length=max_length,
+            state_initializer=state_initializer,
+            normalizer=_identity,
+            distribution=_argmax,
+        )
+
+
+def _nd_multinomial(probabilities: mx.np.ndarray) -> int:
+    sample = mx.random.multinomial(probabilities.as_nd_ndarray())
+    sample = sample.as_np_ndarray().item()
+    return sample
+
+
+# noinspection PyUnresolvedReferences
+_numpy_softmax = mx.npx.softmax
+
+
+class SoftmaxSearch(BaseSearch):
+    """Softmax with a sensitivity parameter followed by sampling from multinomial
+    distribution.
+
+    Parameters
+    ----------
+    model : SMILESEncoderDecoderABC
+        A (trained) language model. Generates one token ID in one step.
+    vocabulary : SMILESVocabulary
+        A SMILES vocabulary. Provides id-to-token conversion.
+    prefix : str, default Token.BOS
+        The prefix of a SMILES string to generate.
+    max_length : int, default 80
+        The maximum number of tokens in the SMILES string being generated.
+    temperature : float, default 1.0
+        A sensitivity parameter.
+    state_initializer : callable, any -> mx.nd.NDArray
+        The model's hidden state initializer function (e.g. mx.nd.ones).
+    """
+    def __init__(
+            self,
+            model: SMILESEncoderDecoderABC,
+            vocabulary: SMILESVocabulary,
+            *,
+            prefix: str = Token.BOS,
+            max_length: int = 80,
+            temperature: float = 1.0,
+            state_initializer: Callable[..., mx.nd.NDArray] = mx.nd.zeros,
+            normalizer: Optional[Callable[..., mx.np.ndarray]] = None,
+            distribution: Optional[Callable[..., int]] = None,
+    ):
+        normalizer = normalizer or _numpy_softmax
+        distribution = distribution or _nd_multinomial
+        normalizer_part = functools.partial(normalizer, temperature=temperature)
+
+        super().__init__(
+            model=model,
+            vocabulary=vocabulary,
+            prefix=prefix,
+            max_length=max_length,
+            state_initializer=state_initializer,
+            normalizer=normalizer_part,
+            distribution=distribution,
+        )
+
+        self.temperature = temperature
+
+    @property
+    def temperature(self) -> float:
+        """Return the sensitivity parameter.
+        """
+        return self.__temperature
+
+    @temperature.setter
+    def temperature(self, temperature: float):
+        """Set a new sensitivity parameter. Change also the `normalizer`s temperature.
+
+        Parameters
+        ----------
+        temperature : float
+
+        Raises
+        ------
+        ValueError
+            If `temperature` <= 0.
+        """
+        if temperature <= 0:
+            raise ValueError('temperature must be greater than zero')
+
+        self._normalizer = functools.partial(self._normalizer, temperature=temperature)
+        self.__temperature = temperature
+
+
+def _gumbel_trick(logits: mx.np.ndarray, temperature: float) -> mx.np.ndarray:
+    gumbel = mx.np.random.gumbel(size=logits.shape[0], ctx=logits.ctx)
+    gumbel_logits = (logits - gumbel) / temperature
+    # noinspection PyUnresolvedReferences
+    probabilities = mx.npx.softmax(gumbel_logits, temperature=temperature)
+
+    return probabilities
+
+
+class GumbelSoftmaxSearch(SoftmaxSearch):
+    """Similar to `SoftmaxSearch` but uses the Gumbel-Softmax trick.
+
+    Parameters
+    ----------
+    model : SMILESEncoderDecoderABC
+        A (trained) language model. Generates one token ID in one step.
+    vocabulary : SMILESVocabulary
+        A SMILES vocabulary. Provides id-to-token conversion.
+    prefix : str, default Token.BOS
+        The prefix of a SMILES string to generate.
+    max_length : int, default 80
+        The maximum number of tokens in the SMILES string being generated.
+    temperature : float, default 1.0
+        A sensitivity parameter.
+    state_initializer : callable, any -> mx.nd.NDArray
+        The model's hidden state initializer function (e.g. mx.nd.ones).
+    """
+
+    def __init__(
+            self,
+            model: SMILESEncoderDecoderABC,
+            vocabulary: SMILESVocabulary,
+            *,
+            prefix: str = Token.BOS,
+            max_length: int = 80,
+            temperature: float = 1.0,
+            state_initializer: Callable[..., mx.nd.NDArray] = mx.nd.zeros,
+            normalizer: Optional[Callable[..., mx.np.ndarray]] = None,
+            distribution: Optional[Callable[..., int]] = None,
+    ):
+        normalizer = normalizer or _gumbel_trick
+
+        super().__init__(
+            model=model,
+            vocabulary=vocabulary,
+            prefix=prefix,
+            max_length=max_length,
+            temperature=temperature,
+            state_initializer=state_initializer,
+            normalizer=normalizer,
+            distribution=distribution,
+        )

--- a/tests/test_generation.py
+++ b/tests/test_generation.py
@@ -13,6 +13,7 @@ from moleculegen.data import (
 )
 from moleculegen.estimation import SMILESEncoderDecoder
 from moleculegen.generation import GreedySearch
+from moleculegen.generation.search import SoftmaxSearch, ArgmaxSearch
 from .utils import TempSMILESFile
 
 
@@ -44,6 +45,71 @@ class GreedySearchTestCase(unittest.TestCase):
                     token = token.upper()
 
                 self.assertIn(token, valid_tokens)
+
+    def tearDown(self):
+        self.fh.close()
+
+
+class ArgmaxSearchTestCase(unittest.TestCase):
+    def setUp(self):
+        temp_file = TempSMILESFile(tempfile_kwargs={'prefix': 'argmax_sampler'})
+        self.fh = temp_file.open()
+
+        dataset = SMILESDataset(self.fh.name)
+        self.vocabulary = SMILESVocabulary(dataset, need_corpus=True)
+
+        self.model = SMILESEncoderDecoder(len(self.vocabulary))
+
+        self.predictor = ArgmaxSearch(self.model, self.vocabulary)
+
+    def test_1_distribution(self):
+        logits = mx.np.array([-10.5, -10.7, 0.5, 20.3, 30.1])
+        next_token_id = self.predictor.distribution(self.predictor.normalizer(logits))
+
+        self.assertEqual(next_token_id, logits.argmax().item())
+
+    def test_2_tokens_are_valid(self):
+        valid_tokens = Token.get_all_tokens() - frozenset(Token.UNK)
+
+        for _ in range(100):
+            smiles = self.predictor()
+
+            for token in Token.tokenize(smiles):
+                if len(token) == 1 and token.islower():
+                    token = token.upper()
+
+                self.assertIn(token, valid_tokens)
+
+    def tearDown(self):
+        self.fh.close()
+
+
+class SoftmaxSamplerTestCase(unittest.TestCase):
+    def setUp(self):
+        temp_file = TempSMILESFile(tempfile_kwargs={'prefix': 'softmax_sampler'})
+        self.fh = temp_file.open()
+
+        dataset = SMILESDataset(self.fh.name)
+        self.vocabulary = SMILESVocabulary(dataset, need_corpus=True)
+
+        self.model = SMILESEncoderDecoder(len(self.vocabulary))
+
+        self.predictor = SoftmaxSearch(self.model, self.vocabulary)
+
+    def test_1_normalizer(self):
+        # Check if probabilities from `self.predictor` sum to 1.
+        logits = mx.np.random.uniform(low=-10, high=20, size=len(self.vocabulary))
+        probabilities = self.predictor.normalizer(logits)
+
+        self.assertAlmostEqual(probabilities.sum().item(), 1.0, 3)
+
+        # Check if high temperature gives almost equal probabilities.
+        self.predictor.temperature = 100 * logits.max().item()
+        probabilities = self.predictor.normalizer(logits)
+
+        expected_prob = 1 / len(self.vocabulary)
+        for prob in probabilities:
+            self.assertAlmostEqual(prob, expected_prob, 2)
 
     def tearDown(self):
         self.fh.close()


### PR DESCRIPTION
See #31 
- [x] A descriptor projection plotter callback `moleculegen.callback.PhysChemDescriptorPlotter`.
- [x] 4 new SMILES generator alternatives: `moleculegen.generation.BaseSearch` (replaces `moleculegen.generation.GreedySearch` with more convenient mxnet-only API), `ArgmaxSearch`, `SoftmaxSearch`, and `GumbelSoftmaxSearch`.
- [x] Revert a dropout option before a decoder block in `moleculegen.estimation.SMILESEncoderDecoderABC`.
- [x] Refactor `scripts/run.py`.