### PR TITLE
Refactor 'moleculegen.description'

### DIFF
--- a/moleculegen/callback/callbacks.py
+++ b/moleculegen/callback/callbacks.py
@@ -43,7 +43,7 @@ from rdkit.Chem import MolFromSmiles
 
 from .base import Callback
 from ..description.base import get_descriptors_df
-from ..description.physicochemical import DESCRIPTOR_FUNCTIONS
+from ..description.physicochemical import PHYSCHEM_DESCRIPTOR_MAP
 from ..evaluation.metric import CompositeMetric, Metric
 from ..generation.search import BaseSearch
 
@@ -592,7 +592,7 @@ class PhysChemDescriptorPlotter(Callback):
         self._image_file_prefix = image_file_prefix
         self._epoch = epoch
 
-        self._train_data_t = get_descriptors_df(train_data, DESCRIPTOR_FUNCTIONS)
+        self._train_data_t = get_descriptors_df(train_data, PHYSCHEM_DESCRIPTOR_MAP)
         self._train_data_t = self._transformer.fit_transform(self._train_data_t)
 
     def on_epoch_begin(self, **fit_kwargs):
@@ -638,7 +638,7 @@ class PhysChemDescriptorPlotter(Callback):
                 with open(f'{self._valid_data_file_prefix}_epoch_{epoch}.csv') as fh:
                     valid_data_desc = get_descriptors_df(
                         [s for s in fh.readlines() if MolFromSmiles(s) is not None],
-                        DESCRIPTOR_FUNCTIONS,
+                        PHYSCHEM_DESCRIPTOR_MAP,
                     )
             else:
                 valid_data_desc = (

--- a/moleculegen/description/__init__.py
+++ b/moleculegen/description/__init__.py
@@ -1,6 +1,11 @@
 """
 Describe molecular feature space w/ encoders and feature transformers.
 
+Constants
+---------
+PHYSCHEM_DESCRIPTOR_MAP
+    Key - descriptor name, value - descriptor callable.
+
 Classes
 -------
 OneHotEncoder
@@ -10,6 +15,8 @@ MorganFingerprint
     Apply the Morgan algorithm to a set of compounds to get circular fingerprints.
 MoleculeTransformer
     Convert SMILES compounds into RDKit molecules.
+RDKitDescriptorTransformer
+    Calculate RDKit descriptors.
 
 
 Functions
@@ -34,6 +41,8 @@ __all__ = (
     'MoleculeTransformer',
     'MorganFingerprint',
     'OneHotEncoder',
+    'PHYSCHEM_DESCRIPTOR_MAP',
+    'RDKitDescriptorTransformer',
 )
 
 
@@ -45,10 +54,12 @@ from .base import (
 from .common import (
     MoleculeTransformer,
     OneHotEncoder,
+    RDKitDescriptorTransformer,
 )
 from .fingerprints import (
     MorganFingerprint,
 )
 from .physicochemical import (
+    PHYSCHEM_DESCRIPTOR_MAP,
     get_physchem_descriptors,
 )

--- a/moleculegen/description/__init__.py
+++ b/moleculegen/description/__init__.py
@@ -7,12 +7,16 @@ OneHotEncoder
     One-hot encoder functor.
 
 MorganFingerprint
-    Apply the Morgan algorithm to a set of compounds to get circular
-    fingerprints.
+    Apply the Morgan algorithm to a set of compounds to get circular fingerprints.
+MoleculeTransformer
+    Convert SMILES compounds into RDKit molecules.
 
 
 Functions
 ---------
+check_compounds_valid
+    Convert SMILES compounds into RDKit molecules.
+
 get_descriptors
     Create a dictionary of descriptors.
 get_descriptors_df
@@ -23,19 +27,23 @@ get_physchem_descriptors
 """
 
 __all__ = (
+    'check_compounds_valid',
     'get_descriptors',
     'get_descriptors_df',
     'get_physchem_descriptors',
+    'MoleculeTransformer',
     'MorganFingerprint',
     'OneHotEncoder',
 )
 
 
 from .base import (
+    check_compounds_valid,
     get_descriptors,
     get_descriptors_df,
 )
 from .common import (
+    MoleculeTransformer,
     OneHotEncoder,
 )
 from .fingerprints import (

--- a/moleculegen/description/base.py
+++ b/moleculegen/description/base.py
@@ -15,10 +15,12 @@ __all__ = (
     'check_compounds_valid',
     'get_descriptors',
     'get_descriptors_df',
+    'get_descriptor_df_from_mol',
 )
 
 
 import array
+from numbers import Real
 from typing import Callable, Dict, Iterable, List
 
 import pandas as pd
@@ -148,3 +150,16 @@ def get_descriptors(
         )
 
     return results
+
+
+def get_descriptor_df_from_mol(
+        molecules: Iterable[Mol],
+        function_map: Dict[str, Callable[[Mol], Real]],
+) -> pd.DataFrame:
+    data_frame = pd.DataFrame()
+
+    for name, function in function_map.items():
+        descriptor: List[Real] = [function(molecule) for molecule in molecules]
+        data_frame = data_frame.assign(**{name: descriptor})
+
+    return data_frame

--- a/moleculegen/description/base.py
+++ b/moleculegen/description/base.py
@@ -3,6 +3,8 @@ Utilities to create tables of descriptors.
 
 Functions
 ---------
+check_compounds_valid
+    Convert SMILES compounds into RDKit molecules.
 get_descriptors
     Create a dictionary of descriptors.
 get_descriptors_df
@@ -10,21 +12,64 @@ get_descriptors_df
 """
 
 __all__ = (
+    'check_compounds_valid',
     'get_descriptors',
     'get_descriptors_df',
 )
 
 
 import array
-from typing import Callable, Dict, MutableSequence
+from typing import Callable, Dict, Iterable, List
 
 import pandas as pd
-from rdkit.Chem import MolFromSmiles
+from rdkit.Chem import Mol, MolFromSmiles
+
+
+def check_compounds_valid(
+        compounds: Iterable[str],
+        raise_exception: bool = False,
+        **converter_kwargs,
+) -> List[Mol]:
+    """Convert SMILES compounds into RDKit molecules. Accept only valid compounds and if
+    `raise_exception` is True, raise TypeError.
+
+    Parameters
+    ----------
+    compounds : iterable of str
+        SMILES compounds.
+    raise_exception : bool, default False
+        If any compound is invalid, raise TypeError.
+    converter_kwargs : dict, default {}
+        Optional key-word arguments for `rdkit.Chem.MolFromSmiles`.
+
+    Returns
+    -------
+    molecules : list of rdkit.Chem.Mol
+
+    Raises
+    ------
+    TypeError
+        If any compound is invalid.
+    """
+    molecules: List[Mol] = []
+
+    for compound in compounds:
+        molecule = MolFromSmiles(compound, **converter_kwargs)
+        if molecule is not None:
+            molecules.append(molecule)
+        elif raise_exception:
+            raise TypeError(
+                f'cannot convert {compound!r} into molecule: invalid compound'
+            )
+
+    return molecules
 
 
 def get_descriptors_df(
-        compounds: MutableSequence[str],
+        compounds: Iterable[str],
         function_map: Dict[str, Callable],
+        raise_exception: bool = False,
+        **converter_kwargs,
 ) -> pd.DataFrame:
     """Create a pandas.DataFrame instance comprising the descriptors of
     `compounds` declared in `function_map`. The resulting data frame's index
@@ -33,25 +78,36 @@ def get_descriptors_df(
 
     Parameters
     ----------
-    compounds : mutable sequence of str
-        (Mutable) Sequence of SMILES strings.
-    function_map : dict
+    compounds : iterable of str
+        SMILES strings.
+    function_map : dict, str -> (callable, rdkit.Chem.Mol -> numbers.Real)
         Keys are the column names being assigned to a data frame,
         values are the descriptor function callables to apply to `compounds`.
+    raise_exception : bool, default False
+        If any compound is invalid, raise TypeError.
+    converter_kwargs : dict, default {}
+        Optional key-word arguments for `rdkit.Chem.MolFromSmiles`.
 
     Returns
     -------
     data_frame : pd.DataFrame
+        Index -- SMILES strings.
+        Column names -- keys of `function_map`.
+        Columns -- descriptor results from `function_map`s mapping.
+
+    Raises
+    ------
+    TypeError
+        If any compound is invalid.
     """
+    molecules: List[Mol] = check_compounds_valid(
+        compounds, raise_exception=raise_exception, **converter_kwargs)
+
     if not isinstance(compounds, pd.DataFrame):
         compounds = pd.DataFrame({'smiles': compounds})
 
     for name, function in function_map.items():
-        results = (
-            compounds['smiles']
-            .pipe(lambda series: series.apply(MolFromSmiles))
-            .pipe(lambda series: series.apply(function))
-        )
+        results = array.array('f', map(function, molecules))
         compounds = compounds.assign(**{name: results})
 
     compounds.set_index(keys='smiles', drop=True, inplace=True)
@@ -60,8 +116,9 @@ def get_descriptors_df(
 
 
 def get_descriptors(
-        compounds: MutableSequence[str],
+        compounds: Iterable[str],
         function_map: Dict[str, Callable],
+        **converter_kwargs,
 ) -> Dict[str, array.array]:
     """Create a dictionary of descriptors, where keys are descriptor names
     from `function_map.keys()` and values are the calculated descriptors
@@ -69,20 +126,25 @@ def get_descriptors(
 
     Parameters
     ----------
-    compounds : mutable sequence of str
-        (Mutable) Sequence of SMILES strings.
-    function_map : dict
+    compounds : iterable of str
+        SMILES strings.
+    function_map : dict, str -> (callable, rdkit.Chem.Mol -> numbers.Real)
         Keys are the names being assigned to a resulting dictionary,
         values are the descriptor function callables to apply to `compounds`.
+    converter_kwargs : dict, default {}
+        Optional key-word arguments for `rdkit.Chem.MolFromSmiles`.
 
     Returns
     -------
     result : dict
     """
+    molecules: List[Mol] = check_compounds_valid(compounds, **converter_kwargs)
     results: Dict[str, array.array] = {}
+
     for name, fn in function_map.items():
         results[name] = array.array(
             'f',
-            (fn(MolFromSmiles(smiles)) for smiles in compounds)
+            (fn(molecule) for molecule in molecules)
         )
+
     return results

--- a/moleculegen/description/common.py
+++ b/moleculegen/description/common.py
@@ -5,14 +5,22 @@ Classes
 -------
 OneHotEncoder
     One-hot encoder functor.
+MoleculeTransformer
+    Convert SMILES compounds into RDKit molecules.
 """
 
 __all__ = (
     'OneHotEncoder',
+    'MoleculeTransformer',
 )
 
+from typing import Iterable, List
 
 import mxnet as mx
+from rdkit.Chem import Mol
+from sklearn.base import BaseEstimator, TransformerMixin
+
+from .base import check_compounds_valid
 
 
 class OneHotEncoder:
@@ -43,3 +51,42 @@ class OneHotEncoder:
                 indices.as_nd_ndarray(), self.depth, *args, **kwargs).as_np_ndarray()
         # noinspection PyUnresolvedReferences
         return mx.npx.one_hot(indices, self.depth, *args, **kwargs)
+
+
+class MoleculeTransformer(BaseEstimator, TransformerMixin):
+    """Convert SMILES compounds into RDKit molecules.
+
+    Parameters
+    ----------
+    converter_kwargs : dict, default {}
+        Optional key-word arguments for `rdkit.Chem.MolFromSmiles`.
+    """
+
+    def __init__(self, **converter_kwargs):
+        self.converter_kwargs = converter_kwargs
+
+    # noinspection PyUnusedLocal
+    def fit(self, compounds: Iterable[str], y_ignored=None) -> 'MoleculeTransformer':
+        return self
+
+    # noinspection PyMethodMayBeStatic
+    def transform(self, compounds: Iterable[str]) -> List[Mol]:
+        """Convert SMILES compounds into RDKit molecules. Raise TypeError if there is an
+        invalid compound.
+
+        Parameters
+        ----------
+        compounds : iterable of str
+            SMILES compounds.
+
+        Returns
+        -------
+        molecules : list of rdkit.Chem.Mol
+
+        Raises
+        ------
+        TypeError
+            If any compound is invalid.
+        """
+        return check_compounds_valid(
+            compounds, raise_exception=True, **self.converter_kwargs)

--- a/moleculegen/description/common.py
+++ b/moleculegen/description/common.py
@@ -72,6 +72,9 @@ class MoleculeTransformer(BaseEstimator, TransformerMixin):
 
     # noinspection PyUnusedLocal
     def fit(self, compounds: Iterable[str], y_ignored=None) -> 'MoleculeTransformer':
+        # noinspection PyAttributeOutsideInit
+        self.n_features_in_ = 1
+
         return self
 
     def transform(self, compounds: Iterable[str]) -> List[Mol]:
@@ -105,6 +108,14 @@ class MoleculeTransformer(BaseEstimator, TransformerMixin):
 
 class RDKitDescriptorTransformer(BaseEstimator, TransformerMixin):
     """Calculate RDKit descriptors.
+
+    Examples
+    --------
+    >>> import moleculegen as mg
+    >>> molecule_tr = mg.description.MoleculeTransformer()
+    >>> rdkit_descriptor_tr = mg.description.RDKitDescriptorTransformer()
+    >>> from sklearn.pipeline import make_pipeline
+    >>> pipe = make_pipeline(molecule_tr, rdkit_descriptor_tr)
     """
 
     # noinspection PyUnusedLocal
@@ -112,6 +123,8 @@ class RDKitDescriptorTransformer(BaseEstimator, TransformerMixin):
         # noinspection PyAttributeOutsideInit
         # noinspection PyProtectedMember
         self.descriptor_names_ = tuple(name for name, func in Descriptors._descList)
+        # noinspection PyAttributeOutsideInit
+        self.n_features_in_ = 1
 
         return self
 

--- a/moleculegen/description/fingerprints.py
+++ b/moleculegen/description/fingerprints.py
@@ -34,10 +34,19 @@ class MorganFingerprint(BaseEstimator, TransformerMixin):
         The number of bits.
     return_sparse : bool, default False
         Whether to return csr-sparse matrix or numpy array.
+
+    Examples
+    --------
+    >>> import moleculegen as mg
+    >>> molecule_tr = mg.description.MoleculeTransformer()
+    >>> ecfp_tr = mg.description.MorganFingerprint(n_bits=1024)
+    >>> from sklearn.pipeline import make_pipeline
+    >>> pipe = make_pipeline(molecule_tr, ecfp_tr)
     """
 
     def __init__(
             self,
+            *,
             radius: int = 4,
             n_bits: int = 2048,
             return_sparse: bool = False,
@@ -63,6 +72,8 @@ class MorganFingerprint(BaseEstimator, TransformerMixin):
         """
         check_scalar(self.radius, 'radius', int, min_val=1)
         check_scalar(self.n_bits, 'number of bits', int, min_val=1)
+        # noinspection PyAttributeOutsideInit
+        self.n_features_in_ = 1
 
         return self
 

--- a/moleculegen/description/physicochemical.py
+++ b/moleculegen/description/physicochemical.py
@@ -13,9 +13,12 @@ __all__ = (
 
 
 import array
-from typing import Dict, MutableSequence
+from numbers import Real
+from typing import Callable, Dict, MutableSequence
 
-from rdkit.Chem.rdMolDescriptors import CalcNumRotatableBonds, CalcTPSA
+from rdkit.Chem import Mol
+from rdkit.Chem.rdMolDescriptors import (
+    CalcNumAliphaticRings, CalcNumAromaticRings, CalcNumRotatableBonds, CalcTPSA)
 from rdkit.Chem.Crippen import MolLogP
 from rdkit.Chem.Descriptors import ExactMolWt
 from rdkit.Chem.GraphDescriptors import BertzCT
@@ -24,7 +27,7 @@ from rdkit.Chem.Lipinski import NumHAcceptors, NumHDonors
 from .base import get_descriptors
 
 
-DESCRIPTOR_FUNCTIONS = {
+DESCRIPTOR_FUNCTIONS: Dict[str, Callable[[Mol], Real]] = {
     '#BertzCT': BertzCT,
     '#RotatableBonds': CalcNumRotatableBonds,
     'TotalPolarSurfaceArea': CalcTPSA,
@@ -32,6 +35,8 @@ DESCRIPTOR_FUNCTIONS = {
     'LogP': MolLogP,
     '#HAcceptors': NumHAcceptors,
     '#HDonors': NumHDonors,
+    '#AliphaticRings': CalcNumAliphaticRings,
+    '#AromaticRings': CalcNumAromaticRings,
 }
 
 

--- a/moleculegen/description/physicochemical.py
+++ b/moleculegen/description/physicochemical.py
@@ -1,6 +1,11 @@
 """
 Create physicochemical descriptors.
 
+Constants
+---------
+PHYSCHEM_DESCRIPTOR_MAP
+    Key - descriptor name, value - descriptor callable.
+
 Functions
 ---------
 get_physchem_descriptors
@@ -8,6 +13,7 @@ get_physchem_descriptors
 """
 
 __all__ = (
+    'PHYSCHEM_DESCRIPTOR_MAP',
     'get_physchem_descriptors',
 )
 
@@ -27,7 +33,7 @@ from rdkit.Chem.Lipinski import NumHAcceptors, NumHDonors
 from .base import get_descriptors
 
 
-DESCRIPTOR_FUNCTIONS: Dict[str, Callable[[Mol], Real]] = {
+PHYSCHEM_DESCRIPTOR_MAP: Dict[str, Callable[[Mol], Real]] = {
     '#BertzCT': BertzCT,
     '#RotatableBonds': CalcNumRotatableBonds,
     'TotalPolarSurfaceArea': CalcTPSA,
@@ -55,4 +61,4 @@ def get_physchem_descriptors(compounds: MutableSequence[str]) \
         A dictionary of descriptors, where keys are descriptor names and
         values are the calculated descriptors.
     """
-    return get_descriptors(compounds, DESCRIPTOR_FUNCTIONS)
+    return get_descriptors(compounds, PHYSCHEM_DESCRIPTOR_MAP)

--- a/tests/test_description.py
+++ b/tests/test_description.py
@@ -6,39 +6,46 @@ import unittest
 
 from numpy import ndarray
 from scipy.sparse import csr_matrix
+from sklearn.pipeline import make_pipeline
 
-from moleculegen.description import MoleculeTransformer, MorganFingerprint
+from moleculegen.description import (
+    check_compounds_valid,
+    MoleculeTransformer,
+    MorganFingerprint,
+    RDKitDescriptorTransformer,
+)
 from .utils import SMILES_STRINGS
 
 
-class ECFPTestCase(unittest.TestCase):
+class MorganFingerprintTestCase(unittest.TestCase):
     def setUp(self):
-        self.smiles_strings = SMILES_STRINGS.split('\n')
+        smiles_strings = SMILES_STRINGS.split('\n')
+        self.molecules = check_compounds_valid(smiles_strings, raise_exception=True)
 
     def test_1_invalid_parameters(self):
         mp = MorganFingerprint(radius=0, n_bits=0)
-        self.assertRaises(ValueError, mp.fit, self.smiles_strings)
+        self.assertRaises(ValueError, mp.fit, self.molecules)
 
         mp.radius = 2
-        self.assertRaises(ValueError, mp.fit, self.smiles_strings)
+        self.assertRaises(ValueError, mp.fit, self.molecules)
 
         mp.n_bits = '1024'
-        self.assertRaises(TypeError, mp.fit, self.smiles_strings)
+        self.assertRaises(TypeError, mp.fit, self.molecules)
 
         mp.radius = 2.0
-        self.assertRaises(TypeError, mp.fit, self.smiles_strings)
+        self.assertRaises(TypeError, mp.fit, self.molecules)
 
         mp.radius = 2
         mp.n_bits = 2048
-        mp.fit(SMILES_STRINGS)
+        mp.fit(self.molecules)
 
     def test_2_transform(self):
         mp = MorganFingerprint(return_sparse=True)
-        ecfp = mp.fit_transform(self.smiles_strings)
+        ecfp = mp.fit_transform(self.molecules)
         self.assertIsInstance(ecfp, csr_matrix)
 
         mp.return_sparse = False
-        ecfp = mp.transform(self.smiles_strings)
+        ecfp = mp.transform(self.molecules)
         self.assertIsInstance(ecfp, ndarray)
 
 
@@ -52,6 +59,20 @@ class MoleculeTransformerTestCase(unittest.TestCase):
 
         with self.assertRaises(TypeError):
             self.transformer.fit_transform(compounds)
+
+
+class RDKitDescriptorTransformerTestCase(unittest.TestCase):
+    def setUp(self):
+        self.compounds = SMILES_STRINGS.split('\n')
+        self.pipe = make_pipeline(MoleculeTransformer(), RDKitDescriptorTransformer())
+
+    def test_1_descriptors(self):
+        descriptors = self.pipe.fit_transform(self.compounds)
+
+        self.assertTupleEqual(
+            descriptors.shape,
+            (len(self.compounds), len(self.pipe[1].descriptor_names_)),
+        )
 
 
 if __name__ == '__main__':

--- a/tests/test_description.py
+++ b/tests/test_description.py
@@ -1,5 +1,5 @@
 """
-Test fingerprint transformers.
+Test sklearn-compatible transformers.
 """
 
 import unittest
@@ -7,7 +7,7 @@ import unittest
 from numpy import ndarray
 from scipy.sparse import csr_matrix
 
-from moleculegen.description import MorganFingerprint
+from moleculegen.description import MoleculeTransformer, MorganFingerprint
 from .utils import SMILES_STRINGS
 
 
@@ -40,6 +40,18 @@ class ECFPTestCase(unittest.TestCase):
         mp.return_sparse = False
         ecfp = mp.transform(self.smiles_strings)
         self.assertIsInstance(ecfp, ndarray)
+
+
+class MoleculeTransformerTestCase(unittest.TestCase):
+    def setUp(self):
+        self.transformer = MoleculeTransformer()
+
+    def test_1_invalid(self):
+        compounds = SMILES_STRINGS.split('\n')
+        compounds.extend(['invalid', '#C%'])
+
+        with self.assertRaises(TypeError):
+            self.transformer.fit_transform(compounds)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
See #31
- [x] Implement `moleculegen.description.check_compounds_valid` to validate and convert SMILES sequences into molecules.
- [x] Revise `get_description*` methods.
- [x] Implement `moleculegen.description.MoleculeTransformer`: sklearn-compatible SMILES-to-molecule transformer.
- [x] Update physicochemical function mapping.
- [x] Scikit-learn-compatible transformers accept RDKit molecules, not SMILES strings.
- [x] Implement `moleculegen.description.RDKitDescriptorTransformer`.