### PR TITLE
Update dataset loaders

### DIFF
--- a/moleculegen/data/__init__.py
+++ b/moleculegen/data/__init__.py
@@ -12,6 +12,8 @@ SMILESConsecutiveSampler
 
 SMILESDataset
     Load text data set containing SMILES strings.
+SMILESTargetDataset
+    SMILES-Activity dataset.
 
 SMILESVocabulary
     Map SMILES characters into their numerical representation.
@@ -29,12 +31,14 @@ __all__ = (
     'SMILESBatchColumnSampler',
     'SMILESConsecutiveSampler',
     'SMILESDataset',
+    'SMILESTargetDataset',
     'SMILESVocabulary',
 )
 
 
 from .loader import (
     SMILESDataset,
+    SMILESTargetDataset,
 )
 from .sampler import (
     SMILESBatchSampler,

--- a/moleculegen/data/loader.py
+++ b/moleculegen/data/loader.py
@@ -5,24 +5,32 @@ Classes
 -------
 SMILESDataset
     Load text data set containing SMILES strings.
+SMILESTargetDataset
+    SMILES-Activity dataset.
 """
 
 __all__ = (
     'SMILESDataset',
+    'SMILESTargetDataset',
 )
 
 
-import io
-from typing import AnyStr, List
+from typing import Any, AnyStr, Callable, Iterator, List, Optional, TextIO, Union
 
-from mxnet.gluon.data import SimpleDataset
+import mxnet as mx
+import numpy as np
+import pandas as pd
 
 from ..base import Token
 
 
-class SMILESDataset(SimpleDataset):
+class SMILESDataset(mx.gluon.data.SimpleDataset):
     """Text data set comprising SMILES strings. Every line is presented as
-    a SMILES string.
+    a SMILES string. No headlines expected.
+
+    Supports Gluon's SimpleDataset API, but also implements `map_`, `filter_`, and
+    `take_` methods, all of which return an iterator, not Gluon's private datasets.
+    Implemented to save memory.
 
     Parameters
     ----------
@@ -30,15 +38,20 @@ class SMILESDataset(SimpleDataset):
         Path to the text file.
     encoding : {'ascii', 'utf8'}, default 'ascii'
         File encoding format.
+    augment : bool, default True
+        Whether to prepend `moleculegen.Token.BOS` and append `moleculegen.Token.EOS` to
+        SMILES strings.
     """
 
     def __init__(
             self,
             filename: AnyStr,
             encoding: str = 'ascii',
+            augment: bool = True,
     ):
         self.__filename = filename
         self.__encoding = encoding
+        self.__augment = augment
 
         smiles_strings = self._read()
         super().__init__(smiles_strings)
@@ -63,6 +76,57 @@ class SMILESDataset(SimpleDataset):
         """
         return self.__encoding
 
+    def map_(self, function: Callable[[str], Any]) -> Iterator[Any]:
+        """Apply `function` to every entry of the data and yield the result.
+
+        Parameters
+        ----------
+        function : callable, str -> any
+
+        Yields
+        ------
+        result : any
+        """
+        return (function(smiles) for smiles in self._data)
+
+    def filter_(self, function: Callable[[str], bool]) -> Iterator[str]:
+        """Filter out the entries with `function(entry) == False`.
+
+        Parameters
+        ----------
+        function : callable, str -> bool
+
+        Yields
+        ------
+        smiles : str
+        """
+        return (smiles for smiles in self._data if function(smiles))
+
+    def take_(
+            self,
+            count: int,
+            replace: bool = False,
+            random_state: Optional[int] = None,
+    ) -> Iterator[str]:
+        """Sample `count` entries, with replacement if `replace=True`.
+
+        Parameters
+        ----------
+        count : int
+            The number of entries to sample.
+        replace : bool, default False
+            Whether to sample with replacement.
+        random_state : int, default None
+            Random seed.
+
+        Yields
+        ------
+        smiles : str
+        """
+        rng = np.random.RandomState(seed=random_state)
+        for index in rng.choice(len(self), size=count, replace=replace):
+            yield self._data[index]
+
     def _read(self) -> List[str]:
         """Read SMILES strings from the specified filename.
 
@@ -73,14 +137,121 @@ class SMILESDataset(SimpleDataset):
         """
         smiles_strings: List[str] = []
 
-        with io.open(self.__filename, encoding=self.__encoding) as fh:
+        if self.__augment:
+            def smiles_fn(s: str) -> str:
+                return Token.augment(s.strip())
+        else:
+            def smiles_fn(s: str) -> str:
+                return s.strip()
+
+        with open(self.__filename, encoding=self.__encoding) as fh:
             for line in fh:
                 if not line:
                     continue
 
-                # Add beginning-of-SMILES and end-of-SMILES tokens to prepare
-                # the data for sampling and fitting.
-                smiles = Token.augment(line.strip())
+                smiles = smiles_fn(line)
                 smiles_strings.append(smiles)
 
         return smiles_strings
+
+
+class SMILESTargetDataset(mx.gluon.data.Dataset):
+    """SMILES-Activity dataset. Loads data from the csv-file named `filename` and stores
+    (augmented) compounds and activities separately in pandas Series. An iterator itself,
+    iterates over active compounds if `generate_only_active=True`; otherwise, generates
+    every compound. Activities are expected to be booleans or integers (0 -- inactive,
+    1 -- active).
+
+    To optionally crop the series of loaded compounds and return them, use
+    `get_smiles_data`. To return the series of activities, use `get_target_data`.
+
+    Parameters
+    ----------
+    filename : str
+        The path to a csv-file.
+    target_column : str
+        The name of the column in the file indicating activities.
+    smiles_column : str, default 'SMILES'
+        The name of the column in the file indicating SMILES strings.
+    augment : bool, default True
+        Whether ot augment the SMILES strings.
+    generate_only_active : bool, default True
+        During iteration, whether to generate only active compounds towards
+        `target_column`.
+    """
+
+    def __init__(
+            self,
+            filename: Union[AnyStr, TextIO],
+            target_column: str,
+            smiles_column: str = 'SMILES',
+            augment: bool = True,
+            generate_only_active: bool = True,
+    ):
+        self._smiles_data = pd.read_csv(filename, usecols=[smiles_column], squeeze=True)
+        self._augmented = augment
+        if augment:
+            self._smiles_data = self._smiles_data.apply(Token.augment)
+
+        self._target_data = pd.read_csv(filename, usecols=[target_column], squeeze=True)
+        self._target_data = self._target_data.astype(np.bool)
+
+        self.generate_only_active = generate_only_active
+        self.__current_index = 0
+
+    def __len__(self) -> int:
+        """Return the total number of compounds.
+        """
+        return self._smiles_data.shape[0]
+
+    def __getitem__(self, index: int) -> str:
+        """Return the SMILES string by index `index`.
+        """
+        return self._smiles_data[index]
+
+    def __iter__(self):
+        return self
+
+    def __next__(self) -> str:
+        try:
+            smiles = self._smiles_data[self.__current_index]
+            smiles_is_active = self._target_data[self.__current_index]
+        except (IndexError, KeyError):
+            self.__current_index = 0
+            raise StopIteration
+        else:
+            self.__current_index += 1
+
+        if (
+                not self.generate_only_active
+                or self.generate_only_active and smiles_is_active
+        ):
+            return smiles
+        else:
+            return self.__next__()
+
+    def get_smiles_data(self, crop: bool = True) -> pd.Series:
+        """If `crop == True`, crop every SMILES string in the series and return them.
+        Otherwise, return the previously loaded series.
+
+        Parameters
+        ----------
+        crop : bool, default True
+            Whether to use `moleculegen.Token.crop` to remove BOS and EOS tokens.
+
+        Returns
+        -------
+        pandas.Series of str
+        """
+        if self._augmented and crop:
+            return self._smiles_data.apply(Token.crop)
+        return self._smiles_data
+
+    def get_target_data(self) -> pd.Series:
+        """Return the series of activities.
+
+        Returns
+        -------
+        pandas.Series of bool
+        """
+        return self._target_data

--- a/moleculegen/description/common.py
+++ b/moleculegen/description/common.py
@@ -139,7 +139,7 @@ class RDKitDescriptorTransformer(BaseEstimator, TransformerMixin):
 
         Returns
         -------
-        descriptors : numpy.ndarray,
+        descriptors : pandas.DataFrame,
                 shape = (`len(molecules)`, `len(self.descriptor_names_)`)
         """
         # noinspection PyProtectedMember
@@ -148,4 +148,4 @@ class RDKitDescriptorTransformer(BaseEstimator, TransformerMixin):
             function_map=dict(Descriptors._descList),
         )
 
-        return descriptor_df.values
+        return descriptor_df

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -3,13 +3,16 @@ Test `SMILESDataset` and `SMILESBatchColumnSampler` classes and their
 components.
 """
 
+import tempfile
 import unittest
+from typing import Iterator
 
 from moleculegen import Token
 from moleculegen.data import (
     SMILESBatchColumnSampler,
     SMILESConsecutiveSampler,
     SMILESDataset,
+    SMILESTargetDataset,
     SMILESVocabulary,
 )
 from .utils import TempSMILESFile
@@ -22,27 +25,101 @@ class SMILESDatasetTestCase(unittest.TestCase):
 
         self.item_list = self.temp_file.smiles_strings.split('\n')
 
-    def test_read(self):
-        dataset = SMILESDataset(self.fh.name)
+        self.dataset = SMILESDataset(self.fh.name)
+
+    def test_1_read(self):
 
         self.assertTrue(
             all(
                 s.startswith(Token.BOS) and s.endswith(Token.EOS)
-                for s in dataset
+                for s in self.dataset
             )
         )
         self.assertListEqual(
             self.item_list,
-            [Token.crop(s) for s in dataset],
+            [Token.crop(s) for s in self.dataset],
         )
 
         self.assertEqual(
             len(self.item_list),
-            len(dataset),
+            len(self.dataset),
         )
+
+    def test_2_map_(self):
+        mapped_data_iter = self.dataset.map_(Token.crop)
+
+        self.assertIsInstance(mapped_data_iter, Iterator)
+        self.assertListEqual(self.item_list, list(mapped_data_iter))
+
+    def test_3_filter_(self):
+        filtered_data_iter = self.dataset.filter_(lambda s: len(s) < 10)
+
+        self.assertIsInstance(filtered_data_iter, Iterator)
+        self.assertListEqual(['{N#N}', '{CN=C=O}'], list(filtered_data_iter))
 
     def tearDown(self):
         self.fh.close()
+
+
+class SMILESTargetDatasetTestCase(unittest.TestCase):
+    def setUp(self):
+        self.data = (
+            'SMILES,Activity\n'
+            'CC[C@H](O1)CC[C@@]12CCCO2,1\n'
+            'CC(C)[C@@]12C[C@@H]1[C@@H](C)C(=O)C2,0\n'
+            'OCCc1c(C)[n+](cs1)Cc2cnc(C)nc2N,0\n'
+            'CC(=O)NCCC1=CNc2c1cc(OC)cc2,1\n'
+            'CCc1c[n+]2ccc3c4ccccc4[nH]c3c2cc1,0\n'
+        )
+        self.only_smiles = [line[:-2] for line in self.data.split('\n')[1:-1]]
+
+        self.file_handler = tempfile.NamedTemporaryFile(mode='w+', encoding='ascii')
+        self.file_handler.write(self.data)
+        self.file_handler.seek(0)
+
+        self.dataset = SMILESTargetDataset(
+            filename=self.file_handler.name,
+            target_column='Activity',
+            smiles_column='SMILES',
+            augment=True,
+            generate_only_active=True,
+        )
+
+    def test_1_len(self):
+        self.assertEqual(5, len(self.dataset))
+
+    def test_2_getitem(self):
+
+        for i in range(len(self.only_smiles)):
+            self.assertEqual(
+                self.only_smiles[i],
+                Token.crop(self.dataset[i]),  # `augment` was set to `True` during init.
+            )
+
+    def test_3_iter(self):
+        only_active = ['CC[C@H](O1)CC[C@@]12CCCO2', 'CC(=O)NCCC1=CNc2c1cc(OC)cc2']
+
+        self.assertIsInstance(self.dataset, Iterator)
+        self.assertListEqual(only_active, list(map(Token.crop, self.dataset)))
+
+        self.dataset.generate_only_active = False
+
+        self.assertListEqual(self.only_smiles, list(map(Token.crop, self.dataset)))
+
+    def test_4_smiles_data(self):
+        self.assertSequenceEqual(
+            self.only_smiles,
+            self.dataset.get_smiles_data(crop=True).tolist(),
+        )
+
+    def test_5_target_data(self):
+        self.assertSequenceEqual(
+            [True, False, False, True, False],
+            self.dataset.get_target_data().tolist(),
+        )
+
+    def tearDown(self):
+        self.file_handler.close()
 
 
 class SMILESBatchColumnSamplerTestCase(unittest.TestCase):


### PR DESCRIPTION
See #31 

- [x] Make augmenting SMILES strings optional in `moleculegen.data.SMILESDataset`;
- [x] Add `map_`, `filter_`, and `take_` to `SMILESDataset`;
- [x] Implement `moleculegen.data.SMILESTargetDataset` to both train/fine-tune a language model train a QSAR model;
- [x] `moleculegen.description.RDKitDescriptorTransformer` transforms results into a pandas DataFrame.