### PR TITLE
Add options to share embedding weights and freeze blocks.

### DIFF
--- a/moleculegen/estimation/_gluon_common.py
+++ b/moleculegen/estimation/_gluon_common.py
@@ -2,7 +2,7 @@
 Gluon objects and sequential models used in the subpackage.
 """
 
-from typing import Dict
+from typing import Dict, Optional
 
 import mxnet as mx
 from mxnet import gluon
@@ -37,6 +37,7 @@ def mlp(
         dtype: str,
         dropout: float,
         prefix: str,
+        params: Optional[mx.gluon.ParameterDict],
 ) -> gluon.Block:
     """A single dense layer or an MLP built with mxnet.gluon.nn.HybridSequential.
     """
@@ -45,6 +46,7 @@ def mlp(
         dtype=dtype,
         flatten=False,
         prefix=prefix if n_layers == 1 else None,
+        params=params,
     )
 
     if dropout <= 1e-3 and n_layers == 1:

--- a/moleculegen/estimation/model.py
+++ b/moleculegen/estimation/model.py
@@ -249,6 +249,7 @@ class SMILESEncoderDecoder(SMILESEncoderDecoderABC):
         return cls(
             vocab_size=raw_data['vocab_size'],
             initialize=raw_data['initialize'],
+            tie_weights=raw_data['tie_weights'],
             dtype=raw_data['dtype'],
             ctx=_gluon_common.CTX_MAP[raw_data['ctx'].lower()],
             prefix=raw_data['prefix'],

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,6 @@ setup(
     packages=find_packages(exclude=['*tests']),
     include_package_data=False,
     install_requires=[
-        'mxnet-cu101',
+        'mxnet',
     ],
 )


### PR DESCRIPTION
See #31 
- [x] `moleculegen.estimation.SMILESEncoderDecoder` can tie the parameters of embedding and decoder blocks.
- [x] `SMILESEncoderDecoder` and `moleculegen.estimation.SMILESEncoderDecoderFineTuner` can freeze their embedding and encoder parameters during fine-tuning.