### PR TITLE
Implement the KL divergence for physicochemical descriptors.

### DIFF
--- a/moleculegen/callback/base.py
+++ b/moleculegen/callback/base.py
@@ -27,6 +27,8 @@ from typing import Any, Callable, List, Optional, TextIO
 
 class Callback(metaclass=abc.ABCMeta):
     """An ABC to build new callbacks.
+
+    # ??? Do we need `on_train_begin` and `on_train_end` methods?
     """
 
     def on_batch_begin(self, **fit_kwargs):

--- a/moleculegen/description/base.py
+++ b/moleculegen/description/base.py
@@ -101,18 +101,18 @@ def get_descriptors_df(
     ------
     TypeError
         If any compound is invalid.
+
+    # ??? Should we include SMILES strings?
     """
     molecules: List[Mol] = check_compounds_valid(
         compounds, raise_exception=raise_exception, **converter_kwargs)
 
     if not isinstance(compounds, pd.DataFrame):
-        compounds = pd.DataFrame({'smiles': compounds})
+        compounds = pd.DataFrame()
 
     for name, function in function_map.items():
         results = array.array('f', map(function, molecules))
         compounds = compounds.assign(**{name: results})
-
-    compounds.set_index(keys='smiles', drop=True, inplace=True)
 
     return compounds
 

--- a/moleculegen/description/physicochemical.py
+++ b/moleculegen/description/physicochemical.py
@@ -34,7 +34,7 @@ from .base import get_descriptors
 
 
 PHYSCHEM_DESCRIPTOR_MAP: Dict[str, Callable[[Mol], Real]] = {
-    '#BertzCT': BertzCT,
+    'BertzCT': BertzCT,
     '#RotatableBonds': CalcNumRotatableBonds,
     'TotalPolarSurfaceArea': CalcTPSA,
     'MolecularWeight': ExactMolWt,

--- a/moleculegen/evaluation/__init__.py
+++ b/moleculegen/evaluation/__init__.py
@@ -31,6 +31,7 @@ get_mask_for_loss
 __all__ = (
     'get_mask_for_loss',
     'CompositeMetric',
+    'KLDivergence',
     'MaskedSoftmaxCELoss',
     'Metric',
     'Novelty',
@@ -47,6 +48,7 @@ from .loss import (
 )
 from .metric import (
     CompositeMetric,
+    KLDivergence,
     Metric,
     Novelty,
     Perplexity,

--- a/moleculegen/evaluation/metric.py
+++ b/moleculegen/evaluation/metric.py
@@ -68,6 +68,14 @@ class Metric(metaclass=abc.ABCMeta):
         self._result: Real = 0.0  # The accumulated result.
         self._n_samples: int = 0  # The number of samples evaluated.
 
+    @property
+    def name(self) -> str:
+        return self.__name
+
+    @property
+    def empty_value(self) -> Any:
+        return self.__empty_value
+
     def __repr__(self) -> str:
         return f'<{self.__class__.__name__}(name={self.__name!r}) at {hex(id(self))}>'
 
@@ -519,6 +527,9 @@ class KLDivergence(Metric):
             **kwargs,
     ) -> Tuple[Real, int]:
         descriptors_valid = get_descriptors_df(predictions, PHYSCHEM_DESCRIPTOR_MAP)
+        if descriptors_valid.shape[0] < 2:
+            return self.empty_value, 1
+
         descriptors_train = get_descriptors_df(labels, PHYSCHEM_DESCRIPTOR_MAP)
 
         discrete_cols = set(

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -9,6 +9,7 @@ from rdkit.RDLogger import DisableLog
 
 from moleculegen.evaluation import (
     get_mask_for_loss,
+    KLDivergence,
     MaskedSoftmaxCELoss,
     Novelty,
     Perplexity,
@@ -203,6 +204,18 @@ class RUACTestCase(unittest.TestCase):
         self.ruac.reset()
 
         self.assertEqual(result, 2/5)
+
+
+class KLDivergenceTestCase(unittest.TestCase):
+    def setUp(self):
+        self.metric = KLDivergence()
+
+    def test_1_same_inputs(self):
+        train = ('CCO', 'N#N')
+        valid = train
+        self.metric.update(predictions=valid, labels=train)
+
+        self.assertEqual(self.metric.get()[1], 1.0)
 
 
 class PerplexityTestCase(unittest.TestCase):


### PR DESCRIPTION
See #31
- [x] `moleculegen.evaluation.KLDivergence` metric.
- [x] If KLDivergence is given, `moleculegen.callbacks.EpochMetricScorer` first generates the required number of strings, then evaluates them.
- [x] The resulting data frame from `moleculegen.description.get_descriptors_df` does not include SMILES strings as index.