### PR TITLE
Implement 'description.InternalTanimoto':

### DIFF
--- a/moleculegen/callback/callbacks.py
+++ b/moleculegen/callback/callbacks.py
@@ -298,6 +298,9 @@ class ProgressBar(Callback):
         The character inside a progress bar that indicates the jobs done.
     wait_char : str, default '✗'
         The character inside a progress bar that indicates the jobs waiting.
+
+    TODO Remove time calculation and replace 'Loss' with 'Mean loss' at the end of an
+         epoch.
     """
 
     def __init__(

--- a/moleculegen/description/__init__.py
+++ b/moleculegen/description/__init__.py
@@ -11,6 +11,8 @@ Classes
 OneHotEncoder
     One-hot encoder functor.
 
+InternalTanimoto
+    Build internal Tanimoto similarity matrix.
 MorganFingerprint
     Apply the Morgan algorithm to a set of compounds to get circular fingerprints.
 MoleculeTransformer
@@ -38,6 +40,7 @@ __all__ = (
     'get_descriptors',
     'get_descriptors_df',
     'get_physchem_descriptors',
+    'InternalTanimoto',
     'MoleculeTransformer',
     'MorganFingerprint',
     'OneHotEncoder',
@@ -57,6 +60,7 @@ from .common import (
     RDKitDescriptorTransformer,
 )
 from .fingerprints import (
+    InternalTanimoto,
     MorganFingerprint,
 )
 from .physicochemical import (

--- a/moleculegen/description/__init__.py
+++ b/moleculegen/description/__init__.py
@@ -41,6 +41,7 @@ __all__ = (
     'get_descriptors_df',
     'get_physchem_descriptors',
     'InternalTanimoto',
+    'InvalidSMILESError',
     'MoleculeTransformer',
     'MorganFingerprint',
     'OneHotEncoder',
@@ -53,6 +54,7 @@ from .base import (
     check_compounds_valid,
     get_descriptors,
     get_descriptors_df,
+    InvalidSMILESError,
 )
 from .common import (
     MoleculeTransformer,

--- a/moleculegen/description/fingerprints.py
+++ b/moleculegen/description/fingerprints.py
@@ -3,11 +3,14 @@ Fingerprint transformers.
 
 Classes
 -------
+InternalTanimoto
+    Build internal Tanimoto similarity matrix.
 MorganFingerprint
     Apply the Morgan algorithm to a set of molecules to get circular fingerprints.
 """
 
 __all__ = (
+    'InternalTanimoto',
     'MorganFingerprint',
 )
 
@@ -19,6 +22,7 @@ import scipy.sparse as sparse
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.utils import check_scalar
 from rdkit.Chem import Mol
+from rdkit.DataStructs import BulkTanimotoSimilarity
 from rdkit.Chem.AllChem import GetMorganFingerprintAsBitVect
 
 
@@ -32,8 +36,8 @@ class MorganFingerprint(BaseEstimator, TransformerMixin):
         The radius of fingerprint.
     n_bits : int, default 2048
         The number of bits.
-    return_sparse : bool, default False
-        Whether to return csr-sparse matrix or numpy array.
+    return_type : {'ndarray', 'csr_sparse', 'bitvect_list'}, default 'ndarray'
+        Whether to return csr-sparse matrix, numpy array, or list of rdkit bit vectors.
 
     Examples
     --------
@@ -49,18 +53,14 @@ class MorganFingerprint(BaseEstimator, TransformerMixin):
             *,
             radius: int = 4,
             n_bits: int = 2048,
-            return_sparse: bool = False,
+            return_type: str = 'ndarray',
     ):
         self.radius = radius
         self.n_bits = n_bits
-        self.return_sparse = return_sparse
+        self.return_type = return_type
 
     # noinspection PyUnusedLocal
-    def fit(
-            self,
-            molecules: Iterable[Mol],
-            y_ignored=None,
-    ):
+    def fit(self, molecules: Iterable[Mol], y_ignored=None) -> 'MorganFingerprint':
         """Check the instance parameters and return the instance.
 
         Parameters
@@ -72,6 +72,14 @@ class MorganFingerprint(BaseEstimator, TransformerMixin):
         """
         check_scalar(self.radius, 'radius', int, min_val=1)
         check_scalar(self.n_bits, 'number of bits', int, min_val=1)
+
+        valid_return_types = {'ndarray', 'csr_sparse', 'bitvect_list'}
+        if self.return_type not in valid_return_types:
+            raise ValueError(
+                f'`return_type` must be in {valid_return_types}, '
+                f'not {self.return_type!r}'
+            )
+
         # noinspection PyAttributeOutsideInit
         self.n_features_in_ = 1
 
@@ -95,9 +103,66 @@ class MorganFingerprint(BaseEstimator, TransformerMixin):
             for molecule in molecules
         ]
 
-        if self.return_sparse:
-            matrix_format = sparse.csr_matrix
-        else:
-            matrix_format = np.array
+        if self.return_type == 'ndarray':
+            return np.array(fingerprints, dtype=np.uint8)
+        elif self.return_type == 'csr_sparse':
+            return sparse.csr_matrix(fingerprints, dtype=np.uint8)
+        elif self.return_type == 'bitvect_list':
+            return fingerprints
 
-        return matrix_format(fingerprints, dtype=np.uint8)
+
+class InternalTanimoto(BaseEstimator):
+    """Build internal Tanimoto similarity matrix. Compare ECFPs of molecules.
+
+    Parameters
+    ----------
+    radius : int, default 2
+        The radius of fingerprint.
+    n_bits : int, default 4096
+        The number of bits.
+    """
+
+    def __init__(
+            self,
+            radius: int = 2,
+            n_bits: int = 4096,
+    ):
+        self.radius = radius
+        self.n_bits = n_bits
+
+    # noinspection PyUnusedLocal
+    def fit(self, molecules: Iterable[Mol], y_ignored=None) -> 'InternalTanimoto':
+        self.fit_transform(molecules)
+        return self
+
+    # noinspection PyUnusedLocal
+    def fit_transform(self, molecules: Iterable[Mol], y_ignored=None) -> np.array:
+        """Return Tanimoto similarity matrix.
+
+        Parameters
+        ----------
+        molecules : iterable of rdkit.Chem.Mol
+            RDKit molecules.
+        y_ignored : None
+            This formal parameter will be ignored.
+
+        Returns
+        -------
+        numpy.ndarray, shape = (len(molecules), len(molecules))
+        """
+        ecfp = MorganFingerprint(
+            radius=self.radius, n_bits=self.n_bits, return_type='bitvect_list')
+        fingerprints = ecfp.fit_transform(molecules)
+
+        # noinspection PyAttributeOutsideInit
+        self.ecfp_ = ecfp
+        # noinspection PyAttributeOutsideInit
+        self.n_features_in_ = len(fingerprints)
+
+        sim_matrix = np.ones((self.n_features_in_, self.n_features_in_))
+        for i in range(1, self.n_features_in_):
+            sim_index = BulkTanimotoSimilarity(fingerprints[i], fingerprints[:i])
+            sim_matrix[i, :i] = sim_index
+            sim_matrix[:i, i] = sim_index
+
+        return sim_matrix

--- a/moleculegen/description/fingerprints.py
+++ b/moleculegen/description/fingerprints.py
@@ -116,19 +116,22 @@ class InternalTanimoto(BaseEstimator):
 
     Parameters
     ----------
-    radius : int, default 2
+    radius : int, default=2
         The radius of fingerprint.
-    n_bits : int, default 4096
+    n_bits : int, default=4096
         The number of bits.
+    dtype : str or numpy dtype, default=numpy.float16
     """
 
     def __init__(
             self,
             radius: int = 2,
             n_bits: int = 4096,
+            dtype=np.float16,
     ):
         self.radius = radius
         self.n_bits = n_bits
+        self.dtype = dtype
 
     # noinspection PyUnusedLocal
     def fit(self, molecules: Iterable[Mol], y_ignored=None) -> 'InternalTanimoto':
@@ -160,7 +163,7 @@ class InternalTanimoto(BaseEstimator):
         self.n_features_in_ = 1
 
         n_fingerprints = len(fingerprints)
-        sim_matrix = np.ones((n_fingerprints, n_fingerprints))
+        sim_matrix = np.ones((n_fingerprints, n_fingerprints), dtype=self.dtype)
         for i in range(1, n_fingerprints):
             sim_index = BulkTanimotoSimilarity(fingerprints[i], fingerprints[:i])
             sim_matrix[i, :i] = sim_index

--- a/moleculegen/description/fingerprints.py
+++ b/moleculegen/description/fingerprints.py
@@ -157,10 +157,11 @@ class InternalTanimoto(BaseEstimator):
         # noinspection PyAttributeOutsideInit
         self.ecfp_ = ecfp
         # noinspection PyAttributeOutsideInit
-        self.n_features_in_ = len(fingerprints)
+        self.n_features_in_ = 1
 
-        sim_matrix = np.ones((self.n_features_in_, self.n_features_in_))
-        for i in range(1, self.n_features_in_):
+        n_fingerprints = len(fingerprints)
+        sim_matrix = np.ones((n_fingerprints, n_fingerprints))
+        for i in range(1, n_fingerprints):
             sim_index = BulkTanimotoSimilarity(fingerprints[i], fingerprints[:i])
             sim_matrix[i, :i] = sim_index
             sim_matrix[:i, i] = sim_index

--- a/moleculegen/description/physicochemical.py
+++ b/moleculegen/description/physicochemical.py
@@ -20,7 +20,7 @@ __all__ = (
 
 import array
 from numbers import Real
-from typing import Callable, Dict, MutableSequence
+from typing import Callable, Dict, Iterable
 
 from rdkit.Chem import Mol
 from rdkit.Chem.rdMolDescriptors import (
@@ -46,18 +46,17 @@ PHYSCHEM_DESCRIPTOR_MAP: Dict[str, Callable[[Mol], Real]] = {
 }
 
 
-def get_physchem_descriptors(compounds: MutableSequence[str]) \
-        -> Dict[str, array.array]:
+def get_physchem_descriptors(compounds: Iterable[str]) -> Dict[str, array.array]:
     """Return physicochemical descriptors.
 
     Parameters
     ----------
-    compounds : mutable sequence of str
-        (Mutable) Sequence of SMILES strings.
+    compounds : iterable of str
+        SMILES strings.
 
     Returns
     -------
-    result : dict
+    dict, str -> array.array of float
         A dictionary of descriptors, where keys are descriptor names and
         values are the calculated descriptors.
     """

--- a/moleculegen/evaluation/metric.py
+++ b/moleculegen/evaluation/metric.py
@@ -571,8 +571,8 @@ class KLDivergence(Metric):
         kl_divs = []
 
         for column in continuous_cols:
-            continuous_data_train = descriptors_train[column].values
-            continuous_data_valid = descriptors_valid[column].values
+            continuous_data_train = descriptors_train[column].values.astype(np.float16)
+            continuous_data_valid = descriptors_valid[column].values.astype(np.float16)
 
             try:
                 kl_div = self.calculate_for_continuous(
@@ -581,7 +581,7 @@ class KLDivergence(Metric):
             except np.linalg.LinAlgError:
                 return self.empty_value, 1
 
-        it = InternalTanimoto()
+        it = InternalTanimoto(dtype=np.float16)
         sim_train = it.fit_transform(molecules_train)
         sim_valid = it.fit_transform(molecules_valid)
         np.fill_diagonal(sim_train, 0.)
@@ -596,8 +596,8 @@ class KLDivergence(Metric):
             return self.empty_value, 1
 
         for column in discrete_cols:
-            discrete_data_train = descriptors_train[column].values
-            discrete_data_valid = descriptors_valid[column].values
+            discrete_data_train = descriptors_train[column].values.astype(np.int32)
+            discrete_data_valid = descriptors_valid[column].values.astype(np.int32)
 
             kl_div = self.calculate_for_discrete(
                 discrete_data_train, discrete_data_valid)

--- a/moleculegen/evaluation/metric.py
+++ b/moleculegen/evaluation/metric.py
@@ -41,10 +41,9 @@ import mxnet as mx
 import numpy as np
 import scipy.stats as stats
 from rdkit.Chem import MolFromSmiles
-from sklearn.pipeline import make_pipeline
 
-from ..description.base import get_descriptors_df
-from ..description.common import MoleculeTransformer
+from ..description.base import check_compounds_valid
+from ..description.common import get_descriptor_df_from_mol
 from ..description.fingerprints import InternalTanimoto
 from ..description.physicochemical import PHYSCHEM_DESCRIPTOR_MAP
 
@@ -552,11 +551,16 @@ class KLDivergence(Metric):
             labels: Sequence[str],
             **kwargs,
     ) -> Tuple[Real, int]:
-        descriptors_valid = get_descriptors_df(predictions, PHYSCHEM_DESCRIPTOR_MAP)
-        if descriptors_valid.shape[0] < 2:
+        molecules_valid = check_compounds_valid(predictions, invalid='skip')
+        if len(molecules_valid) < 2:
             return self.empty_value, 1
 
-        descriptors_train = get_descriptors_df(labels, PHYSCHEM_DESCRIPTOR_MAP)
+        descriptors_valid = get_descriptor_df_from_mol(molecules_valid,
+                                                       PHYSCHEM_DESCRIPTOR_MAP)
+
+        molecules_train = check_compounds_valid(labels, invalid='raise')
+        descriptors_train = get_descriptor_df_from_mol(molecules_train,
+                                                       PHYSCHEM_DESCRIPTOR_MAP)
 
         discrete_cols = set(
             c for c in PHYSCHEM_DESCRIPTOR_MAP.keys()
@@ -566,37 +570,42 @@ class KLDivergence(Metric):
 
         kl_divs = []
 
-        for column in discrete_cols:
-            discrete_data_train = descriptors_train[column].values
-            discrete_data_valid = descriptors_valid[column].values
-
-            try:
-                kl_div = self.calculate_for_discrete(
-                    discrete_data_train, discrete_data_valid)
-                kl_divs.append(kl_div)
-            except np.linalg.LinAlgError:
-                return self.empty_value, 1
-
         for column in continuous_cols:
             continuous_data_train = descriptors_train[column].values
             continuous_data_valid = descriptors_valid[column].values
 
-            kl_div = self.calculate_for_continuous(
-                continuous_data_train, continuous_data_valid)
-            kl_divs.append(kl_div)
+            try:
+                kl_div = self.calculate_for_continuous(
+                    continuous_data_train, continuous_data_valid)
+                kl_divs.append(kl_div)
+            except np.linalg.LinAlgError:
+                return self.empty_value, 1
 
-        it_pipe = make_pipeline(MoleculeTransformer(), InternalTanimoto())
-        sim_train = it_pipe.fit_transform(labels)
-        sim_valid = it_pipe.fit_transform(predictions)
+        it = InternalTanimoto()
+        sim_train = it.fit_transform(molecules_train)
+        sim_valid = it.fit_transform(molecules_valid)
         np.fill_diagonal(sim_train, 0.)
         np.fill_diagonal(sim_valid, 0.)
         sim_train = sim_train.max(axis=1)
         sim_valid = sim_valid.max(axis=1)
 
-        kl_div = self.calculate_for_continuous(sim_train, sim_valid)
-        kl_divs.append(kl_div)
+        try:
+            kl_div = self.calculate_for_continuous(sim_train, sim_valid)
+            kl_divs.append(kl_div)
+        except np.linalg.LinAlgError:
+            return self.empty_value, 1
 
-        return np.mean([np.exp(-kl_div) for kl_div in kl_divs]), 1
+        for column in discrete_cols:
+            discrete_data_train = descriptors_train[column].values
+            discrete_data_valid = descriptors_valid[column].values
+
+            kl_div = self.calculate_for_discrete(
+                discrete_data_train, discrete_data_valid)
+            kl_divs.append(kl_div)
+
+        valid_ratio = len(molecules_valid) / len(predictions)
+        result = valid_ratio * np.mean([np.exp(-kl_div) for kl_div in kl_divs])
+        return result, 1
 
 
 class Perplexity(mx.metric.Perplexity):

--- a/tests/test_description.py
+++ b/tests/test_description.py
@@ -11,6 +11,7 @@ from sklearn.pipeline import make_pipeline
 from moleculegen.description import (
     check_compounds_valid,
     InternalTanimoto,
+    InvalidSMILESError,
     MoleculeTransformer,
     MorganFingerprint,
     RDKitDescriptorTransformer,
@@ -21,7 +22,7 @@ from .utils import SMILES_STRINGS
 class MorganFingerprintTestCase(unittest.TestCase):
     def setUp(self):
         smiles_strings = SMILES_STRINGS.split('\n')
-        self.molecules = check_compounds_valid(smiles_strings, raise_exception=True)
+        self.molecules = check_compounds_valid(smiles_strings, invalid='raise')
 
     def test_1_invalid_parameters(self):
         mp = MorganFingerprint(radius=0, n_bits=0)
@@ -52,13 +53,13 @@ class MorganFingerprintTestCase(unittest.TestCase):
 
 class MoleculeTransformerTestCase(unittest.TestCase):
     def setUp(self):
-        self.transformer = MoleculeTransformer()
+        self.transformer = MoleculeTransformer(invalid='raise')
 
     def test_1_invalid(self):
         compounds = SMILES_STRINGS.split('\n')
         compounds.extend(['invalid', '#C%'])
 
-        with self.assertRaises(TypeError):
+        with self.assertRaises(InvalidSMILESError):
             self.transformer.fit_transform(compounds)
 
 

--- a/tests/test_description.py
+++ b/tests/test_description.py
@@ -4,12 +4,13 @@ Test sklearn-compatible transformers.
 
 import unittest
 
-from numpy import ndarray
+import numpy as np
 from scipy.sparse import csr_matrix
 from sklearn.pipeline import make_pipeline
 
 from moleculegen.description import (
     check_compounds_valid,
+    InternalTanimoto,
     MoleculeTransformer,
     MorganFingerprint,
     RDKitDescriptorTransformer,
@@ -40,13 +41,13 @@ class MorganFingerprintTestCase(unittest.TestCase):
         mp.fit(self.molecules)
 
     def test_2_transform(self):
-        mp = MorganFingerprint(return_sparse=True)
+        mp = MorganFingerprint(return_type='csr_sparse')
         ecfp = mp.fit_transform(self.molecules)
         self.assertIsInstance(ecfp, csr_matrix)
 
-        mp.return_sparse = False
+        mp.return_type = 'ndarray'
         ecfp = mp.transform(self.molecules)
-        self.assertIsInstance(ecfp, ndarray)
+        self.assertIsInstance(ecfp, np.ndarray)
 
 
 class MoleculeTransformerTestCase(unittest.TestCase):
@@ -73,6 +74,17 @@ class RDKitDescriptorTransformerTestCase(unittest.TestCase):
             descriptors.shape,
             (len(self.compounds), len(self.pipe[1].descriptor_names_)),
         )
+
+
+class InternalTanimotoTestCase(unittest.TestCase):
+    def test_1_sim_matrix(self):
+        molecules = ['N#N', 'CN=C=O', 'C#N', 'C#C']
+        mt = MoleculeTransformer()
+        it = InternalTanimoto(radius=2, n_bits=4096)
+        pipe = make_pipeline(mt, it)
+        sim_matrix = pipe.fit_transform(molecules)
+
+        self.assertTrue(np.allclose(sim_matrix, sim_matrix.T))
 
 
 if __name__ == '__main__':

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -211,11 +211,18 @@ class KLDivergenceTestCase(unittest.TestCase):
         self.metric = KLDivergence()
 
     def test_1_same_inputs(self):
-        train = ('CCO', 'N#N')
-        valid = train
+        train = (
+            'CN=C=O',
+            'CN1CCC[C@H]1c2cccnc2',
+            'CC[C@H](O1)CC[C@@]12CCCO2',
+            'CN1CCC[C@H]1c2cccnc2',
+            'CC(C)[C@@]12C[C@@H]1[C@@H](C)C(=O)C2',
+            'OCCc1c(C)[n+](cs1)Cc2cnc(C)nc2N',
+        )
+        valid = ('CCO', 'N#N', 'CN=C=O')
         self.metric.update(predictions=valid, labels=train)
 
-        self.assertEqual(self.metric.get()[1], 1.0)
+        self.assertLess(self.metric.get()[1], 0.1)
 
 
 class PerplexityTestCase(unittest.TestCase):


### PR DESCRIPTION
- [x] `moleculegen.description.InternalTanimoto` transformer creates iternal Tanimoto similarity matrix.
- [x] `moleculegen.evaluation.KLDivergence` calculates also the kde of maximum Tanimoto similarity distribution;
- [x] Refactor `moleculegen.description.MorganFingerprint` to include the option to return a list of rdkit bitvectors.
- [x] Revise docs for `moleculegen.description`.
- [x] Replace `raise_exception` parameter w/ `invalid` in `moleculegen.description.check_compounds_valid`.
- [x] **Resulting KL divergence is multiplied by the ratio of valid compounds.**