### PR TITLE
Update Callback and Estimator APIs.

### DIFF
--- a/moleculegen/_types.py
+++ b/moleculegen/_types.py
@@ -1,0 +1,21 @@
+"""
+Common data type annotations used in the project.
+"""
+
+from typing import Callable, List, Literal, Union
+
+from mxnet import context, gluon, init, nd, optimizer
+
+
+Activations = Literal['sigmoid', 'tanh', 'relu', 'softrelu', 'softsign']
+ActivationT = Union[
+    None, Activations, gluon.nn.Activation, Callable[[nd.NDArray], nd.NDArray]]
+
+ContextT = Union[context.Context, List[context.Context]]
+
+Initializers = Literal['uniform', 'normal', 'orthogonal', 'xavier']
+InitializerT = Union[None, Initializers, init.Initializer]
+
+Optimizers = Literal[
+    'sgd', 'nag', 'adagrad', 'rmsprop', 'adadelta', 'adam', 'nadam', 'ftml']
+OptimizerT = Union[Optimizers, optimizer.Optimizer]

--- a/moleculegen/callback/base.py
+++ b/moleculegen/callback/base.py
@@ -292,8 +292,6 @@ class CallbackList:
             self._begin_time = time.time()
 
     def _log_train_time(self):
-        assert self._begin_time is not None, 'timer was not launched'
-
         if self._log_handler is not None or self._verbose:
             end_time = time.time() - self._begin_time
 

--- a/moleculegen/callback/base.py
+++ b/moleculegen/callback/base.py
@@ -27,9 +27,13 @@ from typing import Any, Callable, List, Optional, TextIO
 
 class Callback(metaclass=abc.ABCMeta):
     """An ABC to build new callbacks.
-
-    # ??? Do we need `on_train_begin` and `on_train_end` methods?
     """
+
+    def on_train_begin(self, **fit_kwargs):
+        """Call at the beginning of training process."""
+
+    def on_train_end(self, **fit_kwargs):
+        """Call at the end of training process."""
 
     def on_batch_begin(self, **fit_kwargs):
         """Call at the beginning of batch sampling."""
@@ -172,6 +176,16 @@ class CallbackList:
                     caller(**fit_kwargs)
 
         call()
+
+    def on_train_begin(self, **fit_kwargs):
+        """Call at the beginning of training process.
+        """
+        self._callbacks_call('on_train_begin', **fit_kwargs)
+
+    def on_train_end(self, **fit_kwargs):
+        """Call at the end of training process.
+        """
+        self._callbacks_call('on_train_end', **fit_kwargs)
 
     def on_batch_begin(self, **fit_kwargs):
         """Call at the beginning of batch sampling.

--- a/moleculegen/callback/callbacks.py
+++ b/moleculegen/callback/callbacks.py
@@ -350,6 +350,16 @@ class ProgressBar(Callback):
         """
         self._bar: Deque[str] = collections.deque([self.__wait_char] * length)
 
+    def on_train_begin(self, **fit_kwargs):
+        """Compute and save the number of batches.
+
+        Parameters
+        ----------
+        Expected named arguments:
+            - batch_sampler
+        """
+        self._n_batches = len(fit_kwargs.get('batch_sampler'))
+
     def on_epoch_begin(self, **fit_kwargs):
         """Initialize a progress bar and a loss list. Start countdown. Retrieve the
         number of epochs and batches.
@@ -368,7 +378,6 @@ class ProgressBar(Callback):
 
         self._loss_list = []
 
-        self._n_batches = len(fit_kwargs.get('batch_sampler'))
         self._batches_per_char = self._n_batches // self.__length or 1
         self._batch_digits = len(str(self._n_batches))
 
@@ -665,7 +674,7 @@ class PhysChemDescriptorPlotter(Callback):
                     valid_data_desc = get_descriptors_df(
                         compounds=fh.readlines(),
                         function_map=PHYSCHEM_DESCRIPTOR_MAP,
-                        invalid='raise',
+                        invalid='skip',
                     )
             else:
                 valid_data_desc = (

--- a/moleculegen/data/__init__.py
+++ b/moleculegen/data/__init__.py
@@ -1,49 +1,30 @@
 """
 Load data from files, create vocabularies, generate mini-batch samplers.
 
-Classes
--------
-SMILESBatchSampler
-    Generate batches of SMILES sequences using specified sampler.
-SMILESBatchColumnSampler
-    Generate batches of SMILES subsequences "column-wise".
-SMILESBatchRandomSampler
-    Generate batches of SMILES subsequences randomly.
-SMILESConsecutiveSampler
-    Generate samples of SMILES subsequences "consecutively".
-SMILESRandomSampler
-    Sample SMILES sequences randomly.
+Classes:
+    SMILESBatchSampler: Generate batches of SMILES sequences using specified sampler.
+    SMILESBatchColumnSampler: Generate batches of SMILES subsequences "column-wise".
+    SMILESConsecutiveSampler: Generate samples of SMILES subsequences "consecutively".
+    SMILESRandomSampler: Sample SMILES sequences randomly.
 
-SMILESDataset
-    Load text data set containing SMILES strings.
-SMILESTargetDataset
-    SMILES-Activity dataset.
+    SMILESDataset: Load text data set containing SMILES strings.
+    SMILESTargetDataset: SMILES-Activity dataset.
 
-SMILESVocabulary
-    Map SMILES characters into their numerical representation.
+    SMILESVocabulary: Map SMILES characters into their numerical representation.
 
-StateInitializerMixin
-    A mixin class for specific state initialization techniques during
-    model training.
-
-
-Functions
----------
-count_tokens
-    Create token counter.
+Functions:
+    count_tokens: Create token counter.
 """
 
 __all__ = (
     'count_tokens',
     'SMILESBatchSampler',
     'SMILESBatchColumnSampler',
-    'SMILESBatchRandomSampler',
     'SMILESConsecutiveSampler',
     'SMILESRandomSampler',
     'SMILESDataset',
     'SMILESTargetDataset',
     'SMILESVocabulary',
-    'StateInitializerMixin',
 )
 
 
@@ -54,10 +35,8 @@ from .loader import (
 from .sampler import (
     SMILESBatchSampler,
     SMILESBatchColumnSampler,
-    SMILESBatchRandomSampler,
     SMILESConsecutiveSampler,
     SMILESRandomSampler,
-    StateInitializerMixin,
 )
 from .vocabulary import (
     count_tokens,

--- a/moleculegen/estimation/__init__.py
+++ b/moleculegen/estimation/__init__.py
@@ -1,29 +1,16 @@
 """
 Create, train, evaluate, and fine-tune generative models.
 
-Classes
--------
-SMILESEncoderDecoderABC
-    An ABC for a generative recurrent neural network to encode-decode SMILES strings.
-SMILESEncoderDecoder
-    A generative recurrent neural network to encode-decode SMILES strings.
-SMILESEncoderDecoderFineTuner
-    The fine-tuner of SMILESEncoderDecoder model.
+Classes:
+    SMILESLM: An ABC for generative language models.
+    SMILESRNN: A generative recurrent neural network to encode-decode SMILES strings.
 """
 
 __all__ = (
     'SMILESLM',
-    'SMILESEncoderDecoder',
-    'SMILESEncoderDecoderABC',
-    'SMILESEncoderDecoderFineTuner',
+    'SMILESRNN',
 )
 
 
-from .base import (
-    SMILESEncoderDecoderABC,
-    SMILESLM,
-)
-from .model import (
-    SMILESEncoderDecoder,
-    SMILESEncoderDecoderFineTuner,
-)
+from .base import SMILESLM
+from .rnn import SMILESRNN

--- a/moleculegen/estimation/__init__.py
+++ b/moleculegen/estimation/__init__.py
@@ -12,13 +12,17 @@ SMILESEncoderDecoderFineTuner
 """
 
 __all__ = (
+    'SMILESLM',
     'SMILESEncoderDecoder',
     'SMILESEncoderDecoderABC',
     'SMILESEncoderDecoderFineTuner',
 )
 
 
-from .base import SMILESEncoderDecoderABC
+from .base import (
+    SMILESEncoderDecoderABC,
+    SMILESLM,
+)
 from .model import (
     SMILESEncoderDecoder,
     SMILESEncoderDecoderFineTuner,

--- a/moleculegen/estimation/_gluon_common.py
+++ b/moleculegen/estimation/_gluon_common.py
@@ -2,10 +2,12 @@
 Gluon objects and sequential models used in the subpackage.
 """
 
-from typing import Dict, Optional
+from typing import Dict, List, Optional, Union
 
 import mxnet as mx
 from mxnet import gluon
+
+from .._types import ActivationT
 
 
 # Available RNNs.
@@ -31,16 +33,33 @@ CTX_MAP: Dict[str, mx.context.Context] = {
 def mlp(
         *,
         n_layers: int,
-        n_units: int,
-        activation: str,
+        n_units: Union[int, List[int]],
+        activation: Union[ActivationT, List[ActivationT]],
         output_dim: int,
         dtype: str,
-        dropout: float,
-        prefix: str,
-        params: Optional[mx.gluon.ParameterDict],
+        dropout: Union[float, List[float]],
+        prefix: Optional[str] = 'decoder_',
+        params: Optional[mx.gluon.ParameterDict] = None,
 ) -> gluon.Block:
     """A single dense layer or an MLP built with mxnet.gluon.nn.HybridSequential.
     """
+    n_hidden_layers = n_layers - 1
+
+    if isinstance(n_units, int):
+        n_units = [n_units] * n_hidden_layers
+    elif len(n_units) != n_hidden_layers:
+        raise ValueError(f'`n_units` must contain exactly `n_layers-1` elements.')
+
+    if not isinstance(activation, list):
+        activation = [activation] * n_hidden_layers
+    elif len(activation) != n_hidden_layers:
+        raise ValueError(f'`activation` must contain exactly `n_layers-1` elements.')
+
+    if isinstance(dropout, float):
+        dropout = [dropout] * n_hidden_layers
+    elif len(dropout) != n_hidden_layers:
+        raise ValueError(f'`dropout` must contain exactly `n_layers-1` elements.')
+
     output_dense = gluon.nn.Dense(
         units=output_dim,
         dtype=dtype,
@@ -49,23 +68,19 @@ def mlp(
         params=params,
     )
 
-    if dropout <= 1e-3 and n_layers == 1:
+    if n_layers == 1:
         return output_dense
 
     net = gluon.nn.HybridSequential(prefix=prefix)
-
-    if dropout > 1e-3:
-        net.add(gluon.nn.Dropout(dropout))
-
-    for _ in range(n_layers-1):
+    for i in range(n_hidden_layers):
         net.add(gluon.nn.Dense(
-            units=n_units,
+            units=n_units[i],
+            activation=activation[i],
             dtype=dtype,
-            activation=activation,
             flatten=False,
         ))
-        if dropout > 1e-3:
-            net.add(gluon.nn.Dropout(dropout))
+        if dropout != 0.:
+            net.add(gluon.nn.Dropout(dropout[i]))
 
     net.add(output_dense)
 

--- a/moleculegen/estimation/base.py
+++ b/moleculegen/estimation/base.py
@@ -15,6 +15,7 @@ __all__ = (
 
 import abc
 import json
+import warnings
 from typing import Callable, List, Optional, Sequence, TextIO, Tuple
 
 import mxnet as mx
@@ -47,6 +48,15 @@ class SMILESEncoderDecoderABC(gluon.HybridBlock, metaclass=abc.ABCMeta):
             prefix: Optional[str] = None,
             params: Optional[gluon.ParameterDict] = None,
     ):
+        warnings.warn(
+            message=(
+                f'{self.__class__.__name__} is deprecated; '
+                f'wil be removed in 1.1.0.'
+                f'consider `moleculegen.estimation.SMILESLM` instead.'
+            ),
+            category=DeprecationWarning,
+        )
+
         super().__init__(prefix=prefix, params=params)
 
         self.__ctx = ctx

--- a/moleculegen/estimation/base.py
+++ b/moleculegen/estimation/base.py
@@ -201,6 +201,8 @@ class SMILESEncoderDecoderABC(gluon.HybridBlock, metaclass=abc.ABCMeta):
             trainer = gluon.Trainer(self.collect_params(), optimizer)
             state_func: Callable = batch_sampler.init_state_func()
 
+            callback_list.on_train_begin(**init_params)
+
             for epoch in range(1, n_epochs + 1):
 
                 init_params['epoch'] = epoch
@@ -237,6 +239,8 @@ class SMILESEncoderDecoderABC(gluon.HybridBlock, metaclass=abc.ABCMeta):
 
                 init_params['model'] = self
                 callback_list.on_epoch_end(**init_params, **train_params)
+
+            callback_list.on_train_end(**init_params)
 
         except KeyboardInterrupt:
             init_params['model'] = self

--- a/moleculegen/estimation/base.py
+++ b/moleculegen/estimation/base.py
@@ -8,11 +8,13 @@ SMILESEncoderDecoderABC
 """
 
 __all__ = (
+    'SMILESLM',
     'SMILESEncoderDecoderABC',
 )
 
 
 import abc
+import json
 from typing import Callable, List, Optional, Sequence, TextIO, Tuple
 
 import mxnet as mx
@@ -21,6 +23,7 @@ from mxnet import autograd, gluon
 from ..callback.base import Callback, CallbackList
 from ..data.sampler import BatchSampler
 from ..evaluation.loss import get_mask_for_loss
+from .._types import ContextT, InitializerT, OptimizerT
 
 
 class SMILESEncoderDecoderABC(gluon.HybridBlock, metaclass=abc.ABCMeta):
@@ -253,3 +256,231 @@ class SMILESEncoderDecoderABC(gluon.HybridBlock, metaclass=abc.ABCMeta):
             # If `log_handler` is a file-like and was opened.
             if log_handler is not None:
                 log_handler.close()
+
+
+class SMILESLM(mx.gluon.Block, metaclass=abc.ABCMeta):
+    """An ABC for generative language models.
+
+    Parameters
+    ----------
+    ctx : mxnet.context.Context or list of mxnet.context.Context,
+            default=mxnet.context.cpu()
+        CPU or GPU.
+
+    Other Parameters
+    ----------------
+    prefix : str, default=None
+    params : mxnet.gluon.ParameterDict, default=None
+    """
+
+    def __init__(
+            self,
+            ctx: Optional[ContextT] = None,
+            prefix: Optional[str] = None,
+            params: Optional[mx.gluon.ParameterDict] = None,
+    ):
+        super().__init__(prefix=prefix, params=params)
+
+        self.__ctx = ctx or mx.context.cpu()
+
+    @property
+    @abc.abstractmethod
+    def embedding(self) -> mx.gluon.Block:
+        """Return the embedding block (e.g. mxnet.gluon.Embedding or OneHotEncoder)."""
+
+    @property
+    @abc.abstractmethod
+    def encoder(self) -> mx.gluon.Block:
+        """Return the encoder block (e.g. mxnet.gluon.rnn.GRU)."""
+
+    @property
+    @abc.abstractmethod
+    def decoder(self) -> mx.gluon.Block:
+        """Return the decoder (e.g. mxnet.gluon.nn.Dense)."""
+
+    @abc.abstractmethod
+    def forward(self, inputs, *args, **kwargs):
+        """Run forward computation."""
+
+    @property
+    def ctx(self) -> ContextT:
+        """Return the model's context.
+        """
+        return self.__ctx
+
+    @ctx.setter
+    def ctx(self, ctx: ContextT):
+        """Set the model's context and reset the parameters' context.
+        """
+        if ctx != self.__ctx:
+            self.collect_params().reset_ctx(ctx)
+            self.__ctx = ctx
+
+    def fit(
+            self,
+            batch_sampler: BatchSampler,
+            optimizer: OptimizerT = 'adam',
+            loss_fn: Optional[mx.gluon.loss.Loss] = None,
+            n_epochs: int = 1,
+            callbacks: Optional[Sequence[Callback]] = None,
+            verbose: Optional[bool] = False,
+            log_filename: Optional[str] = None,
+    ):
+        """Train the model for `n_epochs` number of epochs. Optionally call `callbacks`
+        to monitor training progress.
+
+        Parameters
+        ----------
+        batch_sampler : moleculegen.data.BatchSampler
+            The dataloader to sample mini-batches.
+        optimizer : {'sgd', 'nag', 'adagrad', 'rmsprop', 'adadelta', 'adam', 'nadam',
+                'ftml'} or mxnet.optimizer.Optimizer,
+                default='adam'
+            An mxnet optimizer.
+        loss_fn : mxnet.gluon.loss.Loss, default=mxnet.gluon.loss.SoftmaxCELoss()
+            A gluon loss functor.
+        n_epochs : int, default=1
+            The number of epochs to train.
+        callbacks : moleculegen.callback.CallbackList
+                or sequence of moleculegen.callback.Callback,
+                default=None
+            The callbacks to run during training.
+        verbose : bool, default=False
+            Whether to print logs to stdout.
+        log_filename : str, default=None
+            The path to a log file.
+            If None, callbacks' default options can still print or save some logs. See
+            docs of the callbacks used.
+        """
+        loss_fn = loss_fn or mx.gluon.loss.SoftmaxCELoss()
+        if isinstance(optimizer, str):
+            optimizer = mx.optimizer.create(optimizer)
+
+        # The named arguments required by callbacks on epoch/batch calls.
+        init_params = {
+            # Constant parameters.
+            'batch_sampler': batch_sampler,
+            'optimizer': optimizer,
+            'loss_fn': loss_fn,
+            'n_epochs': n_epochs,
+            # Changeable parameters.
+            'model': self,
+            'epoch': 0,
+        }
+        # The named arguments required by callbacks on batch calls.
+        train_params = dict.fromkeys([
+            'batch_no', 'batch', 'loss', 'predictions', 'outputs'
+        ])
+        callbacks = callbacks or []
+        callback_list: Optional[CallbackList] = None
+        log_handler: Optional[TextIO] = None
+
+        try:
+            if log_filename is not None:
+                log_handler = open(log_filename, 'w')
+
+            trainer = mx.gluon.Trainer(self.collect_params(), optimizer)
+
+            callback_list = CallbackList(log_handler, verbose=verbose)
+            callback_list.add(*callbacks)
+            callback_list.on_train_begin(**init_params)
+
+            for epoch in range(1, n_epochs + 1):
+                # If the inherited model class has a hidden state, `empty_state` is
+                # expected to free its content (e.g. set to None) prior to training.
+                getattr(self, 'empty_state', lambda: None)()
+
+                init_params['epoch'] = epoch
+                callback_list.on_epoch_begin(**init_params)
+
+                for batch_no, batch in enumerate(batch_sampler, start=1):
+                    batch = batch.as_in_ctx(self.__ctx)
+
+                    # If the inherited model class has a hidden state, `begin_state`
+                    # (re)initializes or preserves its content.
+                    getattr(self, 'begin_state', lambda n: None)(batch.shape[0])
+
+                    train_params['batch_no'] = batch_no
+                    train_params['batch'] = batch
+                    callback_list.on_batch_begin(**init_params, **train_params)
+
+                    # noinspection PyUnresolvedReferences
+                    with mx.autograd.record():
+                        predictions = self.forward(batch.inputs)
+                        weights = get_mask_for_loss(batch.shape, batch.valid_lengths)
+                        loss = loss_fn(predictions, batch.outputs, weights)
+                    loss.backward()
+                    trainer.step(batch.valid_lengths.sum())
+
+                    train_params['loss'] = loss
+                    train_params['predictions'] = predictions
+                    train_params['outputs'] = batch.outputs
+                    callback_list.on_batch_end(**init_params, **train_params)
+
+                init_params['model'] = self
+                callback_list.on_epoch_end(**init_params, **train_params)
+
+        except KeyboardInterrupt:
+            init_params['model'] = self
+            # If keyboard interrupt was not triggered before the callback list
+            # initialization.
+            if callback_list is not None:
+                callback_list.on_keyboard_interrupt(**init_params)
+
+        finally:
+            # If `log_handler` is a file-like and was opened.
+            if log_handler is not None:
+                log_handler.close()
+
+            callback_list.on_train_end(**init_params)
+
+    @classmethod
+    def load_fine_tuner(
+            cls,
+            path: str,
+            update_features: bool = False,
+            decoder_init: InitializerT = mx.init.Xavier(),
+    ) -> 'SMILESLM':
+        """Create a new fine-tuner model: load model configuration and parameters, and
+        initialize decoder weights.
+
+        Parameters
+        ----------
+        path : str
+            The path to the directory of model configuration and parameters.
+            path/config.json - the formal parameters of a model;
+            path/weights.params - the parameters of a model.
+        update_features : bool, default=False
+            Whether to update embedding and encoder parameters during training.
+        decoder_init : {'uniform', 'normal', 'orthogonal', 'xavier'}
+                or mxnet.init.Initializer or None,
+                default=mxnet.init.Xavier()
+            The parameter initializer of a dense layer.
+
+        Returns
+        -------
+        model : SMILESLM
+        """
+        model = cls.from_config(f'{path}/config.json')
+        model.load_parameters(f'{path}/weights.params', ctx=model.ctx)
+
+        if not update_features:
+            model.embedding.collect_params().setattr('grad_req', 'null')
+            model.encoder.collect_params().setattr('grad_req', 'null')
+
+        model.decoder.initialize(init=decoder_init, force_reinit=True, ctx=model.ctx)
+
+        return model
+
+    @classmethod
+    def from_config(cls, config_file: str) -> 'SMILESLM':
+        """Load model's formal parameters (arguments) from `config_file` json-file
+        and create a new 'SMILESLM' model.
+
+        Notes
+        -----
+        Specific inherited LM models may require reimplementation of the method depending
+        on their formal parameters.
+        """
+        with open(config_file) as fh:
+            return cls(**json.load(fh))

--- a/moleculegen/estimation/base.py
+++ b/moleculegen/estimation/base.py
@@ -432,7 +432,8 @@ class SMILESLM(mx.gluon.Block, metaclass=abc.ABCMeta):
             if log_handler is not None:
                 log_handler.close()
 
-            callback_list.on_train_end(**init_params)
+            if callback_list is not None:
+                callback_list.on_train_end(**init_params)
 
     @classmethod
     def load_fine_tuner(

--- a/moleculegen/estimation/base.py
+++ b/moleculegen/estimation/base.py
@@ -21,7 +21,7 @@ import mxnet as mx
 from mxnet import autograd, gluon
 
 from ..callback.base import Callback, CallbackList
-from ..data.sampler import BatchSampler
+from ..data.sampler import SMILESBatchSampler
 from ..evaluation.loss import get_mask_for_loss
 from .._types import ContextT, InitializerT, OptimizerT
 
@@ -143,7 +143,7 @@ class SMILESEncoderDecoderABC(gluon.HybridBlock, metaclass=abc.ABCMeta):
 
     def fit(
             self,
-            batch_sampler: BatchSampler,
+            batch_sampler,
             optimizer: mx.optimizer.Optimizer,
             loss_fn: gluon.loss.Loss,
             n_epochs: int = 1,
@@ -318,7 +318,7 @@ class SMILESLM(mx.gluon.Block, metaclass=abc.ABCMeta):
 
     def fit(
             self,
-            batch_sampler: BatchSampler,
+            batch_sampler: SMILESBatchSampler,
             optimizer: OptimizerT = 'adam',
             loss_fn: Optional[mx.gluon.loss.Loss] = None,
             n_epochs: int = 1,
@@ -331,7 +331,7 @@ class SMILESLM(mx.gluon.Block, metaclass=abc.ABCMeta):
 
         Parameters
         ----------
-        batch_sampler : moleculegen.data.BatchSampler
+        batch_sampler : moleculegen.data.SMILESBatchSampler
             The dataloader to sample mini-batches.
         optimizer : {'sgd', 'nag', 'adagrad', 'rmsprop', 'adadelta', 'adam', 'nadam',
                 'ftml'} or mxnet.optimizer.Optimizer,

--- a/moleculegen/estimation/model.py
+++ b/moleculegen/estimation/model.py
@@ -251,7 +251,7 @@ class SMILESEncoderDecoder(SMILESEncoderDecoderABC):
             initialize=raw_data['initialize'],
             tie_weights=raw_data['tie_weights'],
             dtype=raw_data['dtype'],
-            ctx=_gluon_common.CTX_MAP[raw_data['ctx'].lower()],
+            ctx=_gluon_common.get_ctx(raw_data['ctx'].lower()),
             prefix=raw_data['prefix'],
 
             use_one_hot=raw_data['embedding']['use_one_hot'],

--- a/moleculegen/estimation/model.py
+++ b/moleculegen/estimation/model.py
@@ -15,6 +15,7 @@ __all__ = (
 )
 
 import json
+import warnings
 from typing import Optional, Union
 
 import mxnet as mx
@@ -124,6 +125,14 @@ class SMILESEncoderDecoder(SMILESEncoderDecoderABC):
             prefix: Optional[str] = None,
             params: Optional[gluon.ParameterDict] = None,
     ):
+        warnings.warn(
+            message=(
+                f'{self.__class__.__name__} is deprecated; '
+                f'wil be removed in 1.1.0.'
+                f'consider `moleculegen.estimation.SMILESRNN` instead.'
+            ),
+            category=DeprecationWarning,
+        )
         # Validate the formal parameters that are not explicitly sent into and
         # validated in mxnet.gluon objects.
         if not isinstance(use_one_hot, bool):
@@ -378,6 +387,14 @@ class SMILESEncoderDecoderFineTuner(SMILESEncoderDecoderABC):
             prefix: Optional[str] = None,
             params: Optional[gluon.ParameterDict] = None,
     ):
+        warnings.warn(
+            message=(
+                f'{self.__class__.__name__} is deprecated; '
+                f'wil be removed in 1.1.0.'
+                f'consider `moleculegen.estimation.SMILESRNN.load_fine_tuner` instead.'
+            ),
+            category=DeprecationWarning,
+        )
         super().__init__(ctx=ctx, prefix=prefix, params=params)
 
         model.ctx = self.ctx

--- a/moleculegen/estimation/rnn.py
+++ b/moleculegen/estimation/rnn.py
@@ -1,0 +1,354 @@
+"""
+Generative RNN models.
+
+Classes:
+    SMILESRNN: A generative recurrent neural network to encode-decode SMILES strings.
+"""
+
+__all__ = (
+    'SMILESRNN',
+)
+
+import json
+from typing import Callable, List, Optional, Union
+
+import mxnet as mx
+
+from .._types import ActivationT, ContextT, InitializerT
+from ..description.common import OneHotEncoder
+from . import _gluon_common
+from .base import SMILESLM
+
+
+class SMILESRNN(SMILESLM):
+    """A generative recurrent neural network to encode-decode SMILES strings.
+
+    Parameters
+    ----------
+    vocab_size : int
+        The vocabulary dimension, which will indicate the number of output
+        neurons of a decoder.
+    use_one_hot : bool, default=False
+        Whether to use one-hot-encoding or an embedding layer.
+    embedding_dim : int, default=32
+        The output dimension of an embedding layer.
+    embedding_dropout : float, default=0.4
+        The dropout rate of an embedding layer.
+    embedding_init : {'uniform', 'normal', 'orthogonal', 'xavier'}
+            or mxnet.init.Initializer or None,
+            default=mxnet.init.Uniform()
+        The parameter initializer of an embedding layer.
+    embedding_prefix : str, default='embedding_'
+        The prefix of an embedding block.
+    rnn : {'vanilla', 'lstm', 'gru'}, default='lstm'
+        A recurrent layer.
+    rnn_n_layers : int, default=2
+        The number of layers of a (deep) recurrent layer.
+    rnn_n_units : int, default=256
+        The number of neurons in an RNN.
+    rnn_dropout : float, default=0.6
+        The dropout rate of a recurrent layer.
+    rnn_init : {'uniform', 'normal', 'orthogonal', 'xavier'}
+            or mxnet.init.Initializer or None,
+            default=mxnet.init.Orthogonal()
+        The parameter initializer of a recurrent layer.
+    rnn_prefix : str, default='encoder_'
+        The prefix of an encoder block.
+    rnn_state_init : callable, any -> mxnet.nd.NDArray, default=mxnet.nd.zeros
+        The RNN hidden state initializer.
+    rnn_reinit_state : bool, default=False
+        Whether to reinitialize the hidden state on `begin_state` call.
+    rnn_detach_state : bool, default=True
+        Whether to detach the hidden state from the computational graph on `begin_state`
+        call.
+    dense_n_layers : int, default=1
+        The number of dense layers.
+    dense_n_units : int, default=128
+        The number of neurons in each dense layer.
+    dense_activation : {'sigmoid', 'tanh', 'relu', 'softrelu', 'softsign'}
+            or mxnet.gluon.nn.Activation
+            or callable, mxnet.nd.NDArray -> mxnet.nd.NDArray
+            or None,
+            default='relu'
+        The activation function in a dense layer.
+    dense_dropout : float, default=0.5
+        The dropout rate of a dense layer.
+    dense_init : {'uniform', 'normal', 'orthogonal', 'xavier'}
+            or mxnet.init.Initializer or None,
+            default=mxnet.init.Xavier()
+        The parameter initializer of a dense layer.
+    dense_prefix : str, default='decoder_'
+        The prefix of a decoder block.
+    tie_weights : bool, default=False
+        Whether to share the embedding block parameters w/ a decoder block.
+    initialize : bool, default=True
+        Whether to initialize model parameters.
+        When one decides to load parameters from a file, deferred
+        initialization is needless.
+    dtype : str or numpy dtype or None, default='float32'
+        Data type.
+    ctx : mxnet.context.Context or list of mxnet.context.Context,
+            default=mxnet.context.cpu()
+        CPU or GPU.
+
+    Other Parameters
+    ----------------
+    prefix : str, default=None
+    params : mxnet.gluon.ParameterDict, default=None
+
+    Attributes
+    ----------
+    ctx : mxnet.context.Context
+        The model's context.
+    embedding : OneHotEncoder or mxnet.gluon.nn.Embedding
+        An embedding block.
+    encoder : mxnet.gluon.rnn.RNN or mxnet.gluon.rnn.LSTM
+            or mxnet.gluon.rnn.GRU
+        An RNN encoder block.
+    decoder : mxnet.gluon.nn.Dense or mxnet.gluon.nn.Sequential
+        A Feed-Forward NN decoder block.
+    state : list of mxnet.np.ndarray, shape = (rnn_n_layers, batch size, n_rnn_units)
+        The hidden state of `encoder`.
+    state_initializer : callable, any -> mxnet.nd.NDArray
+        The hidden state initializer.
+    reinit_state : bool
+        Whether to reinitialize the hidden state on `begin_state` call.
+    detach_state : bool
+        Whether to detach the hidden state from the computational graph on `begin_state`
+        call.
+    """
+
+    def __init__(
+            self,
+            vocab_size: int,
+            *,
+
+            use_one_hot: bool = False,
+            embedding_dim: int = 32,
+            embedding_dropout: float = 0.4,
+            embedding_init: InitializerT = mx.init.Uniform(),
+            embedding_prefix: str = 'embedding_',
+
+            rnn: str = 'lstm',
+            rnn_n_layers: int = 2,
+            rnn_n_units: int = 256,
+            rnn_dropout: float = 0.6,
+            rnn_init: InitializerT = mx.init.Orthogonal(),
+            rnn_prefix: str = 'encoder_',
+            rnn_state_init: Callable[..., mx.nd.NDArray] = mx.nd.zeros,
+            rnn_reinit_state: bool = False,
+            rnn_detach_state: bool = True,
+
+            dense_n_layers: int = 1,
+            dense_n_units: Union[int, List[int]] = 128,
+            dense_activation: Union[ActivationT, List[ActivationT]] = 'relu',
+            dense_dropout: Union[float, List[float]] = 0.5,
+            dense_init: InitializerT = mx.init.Xavier(),
+            dense_prefix: str = 'decoder_',
+
+            tie_weights: bool = False,
+            initialize: bool = True,
+            dtype: Optional[str] = 'float32',
+            ctx: Optional[ContextT] = None,
+
+            prefix: Optional[str] = None,
+            params: Optional[mx.gluon.ParameterDict] = None,
+    ):
+        # Validate the formal parameters that are not explicitly sent into and
+        # validated in mxnet.gluon objects.
+        if not isinstance(use_one_hot, bool):
+            raise TypeError(
+                '`use_one_hot` must be either True for OneHotEncoder layer '
+                'or False for Embedding layer.'
+            )
+
+        if not isinstance(initialize, bool):
+            raise TypeError(
+                '`initialize` must be either True for deferred '
+                'initialization or False for no initialization.'
+            )
+
+        if rnn not in _gluon_common.RNN_MAP:
+            raise ValueError(
+                f'The recurrent layer must be one of '
+                f'{list(_gluon_common.RNN_MAP.keys())}.'
+            )
+
+        if dense_n_layers < 1:
+            raise ValueError(
+                'The number of dense layers must be positive non-zero.'
+            )
+
+        if (
+                tie_weights
+                and (
+                    embedding_dim != rnn_n_units
+                    or
+                    dense_n_layers > 1
+                    and embedding_dim != dense_n_units
+                )
+        ):
+            raise ValueError(
+                f'When sharing weights, the number of hidden units must be equal to '
+                f'the embedding dimension.'
+            )
+
+        super().__init__(ctx=ctx, prefix=prefix, params=params)
+
+        with self.name_scope():
+            # Define (and initialize) an embedding block.
+            if use_one_hot:
+                self._embedding = OneHotEncoder(vocab_size)
+            else:
+                embedding_block = mx.gluon.nn.Embedding(
+                    input_dim=vocab_size,
+                    output_dim=embedding_dim,
+                    dtype=dtype,
+                    prefix=embedding_prefix,
+                )
+
+                if embedding_dropout != 0.:
+                    seq_prefix = f'{embedding_prefix.rstrip("_")}seq_'
+                    self._embedding = mx.gluon.nn.HybridSequential(prefix=seq_prefix)
+                    self._embedding.add(embedding_block)
+                    self._embedding.add(mx.gluon.nn.Dropout(embedding_dropout))
+                    shared_params = self._embedding[0].params if tie_weights else None
+                else:
+                    self._embedding = embedding_block
+                    shared_params = self._embedding.params if tie_weights else None
+
+                if initialize:
+                    self._embedding.initialize(init=embedding_init, ctx=ctx)
+
+            # Select (and initialize) a recurrent block.
+            self._encoder = _gluon_common.RNN_MAP[rnn](
+                hidden_size=rnn_n_units,
+                num_layers=rnn_n_layers,
+                dropout=rnn_dropout,
+                dtype=dtype,
+                prefix=rnn_prefix,
+            )
+            if initialize:
+                self._encoder.initialize(init=rnn_init, ctx=ctx)
+
+            # Define (and initialize) a dense (sequential) block.
+            self._decoder = _gluon_common.mlp(
+                n_layers=dense_n_layers,
+                n_units=dense_n_units,
+                activation=dense_activation,
+                output_dim=vocab_size,
+                dtype=dtype,
+                dropout=dense_dropout,
+                prefix=dense_prefix,
+                params=shared_params,
+            )
+            if initialize:
+                self._decoder.initialize(init=dense_init, ctx=ctx)
+
+        self._state: Optional[List[mx.np.ndarray]] = None
+        self.state_initializer: Callable[..., mx.nd.NDArray] = rnn_state_init
+        self.reinit_state: bool = rnn_reinit_state
+        self.detach_state: bool = rnn_detach_state
+
+    @property
+    def embedding(self) -> Union[
+            OneHotEncoder, mx.gluon.nn.Embedding, mx.gluon.nn.HybridSequential]:
+        return self._embedding
+
+    @property
+    def encoder(self) -> mx.gluon.rnn.RNN:
+        return self._encoder
+
+    @property
+    def decoder(self) -> Union[mx.gluon.nn.Dense, mx.gluon.nn.HybridSequential]:
+        return self._decoder
+
+    @property
+    def state(self) -> List[mx.np.ndarray]:
+        return self._state
+
+    def empty_state(self):
+        self._state = None
+
+    def state_info(self, batch_size):
+        return self.encoder.state_info(batch_size)
+
+    def begin_state(self, batch_size: int = 0, **func_kwargs):
+        """Reinitialize the hidden state or keep the previous one. Optionally, detach it
+        from the computational graph.
+
+        Parameters
+        ----------
+        batch_size : int, default 0
+            Batch size.
+        func_kwargs
+            Additional arguments for RNN layer's `begin_state` method
+            excluding an mxnet context (we explicitly pass the model's ctx).
+        """
+        if self._state is None or self.reinit_state:
+            self._state = self.encoder.begin_state(
+                batch_size=batch_size, func=self.state_initializer, ctx=self.ctx,
+                **func_kwargs)
+        if self.detach_state:
+            self._state = [s.detach() for s in self._state]
+
+    # noinspection PyMethodOverriding
+    def forward(self, x: mx.np.ndarray) -> mx.np.ndarray:
+        """Run forward computation.
+
+        Parameters
+        ----------
+        x : mxnet.np.ndarray, shape = (batch size, time steps)
+
+        Returns
+        -------
+        mxnet.np.ndarray, shape = (batch size, time steps, vocabulary dimension)
+        """
+        # b=batch size, t=time steps, v=vocab dim, e=embed dim, h=hidden units
+        x = self.embedding(x.T)  # input=(t, b), output=(t, b, e)
+        x, self._state = self.encoder(x, self._state)  # output=(t, b, h)
+        x = self.decoder(x)  # output=(t, b, v)
+        return x.swapaxes(0, 1)  # output=(b, t, v)
+
+    @classmethod
+    def from_config(cls, config_file: str) -> 'SMILESRNN':
+        """Instantiate a model loading its formal parameters from the JSON file named
+        `config_file`.
+
+        Returns
+        -------
+        model : SMILESRNN
+        """
+        with open(config_file) as fh:
+            raw_data = json.load(fh)
+
+        return cls(
+            vocab_size=raw_data['vocab_size'],
+            initialize=raw_data['initialize'],
+            tie_weights=raw_data['tie_weights'],
+            dtype=raw_data['dtype'],
+            ctx=_gluon_common.get_ctx(raw_data['ctx'].lower()),
+            prefix=raw_data['prefix'],
+
+            use_one_hot=raw_data['embedding']['use_one_hot'],
+            embedding_dim=raw_data['embedding']['dim'],
+            embedding_dropout=raw_data['embedding']['dropout'],
+            embedding_init=_gluon_common.INIT_MAP[raw_data['embedding']['init'].lower()],
+            embedding_prefix=raw_data['embedding']['prefix'],
+
+            rnn=raw_data['encoder']['rnn'],
+            rnn_n_layers=raw_data['encoder']['n_layers'],
+            rnn_n_units=raw_data['encoder']['n_units'],
+            rnn_dropout=raw_data['encoder']['dropout'],
+            rnn_init=_gluon_common.INIT_MAP[raw_data['encoder']['init'].lower()],
+            rnn_prefix=raw_data['encoder']['prefix'],
+            rnn_reinit_state=raw_data['encoder']['rnn_reinit_state'],
+            rnn_detach_state=raw_data['encoder']['rnn_detach_state'],
+
+            dense_n_layers=raw_data['decoder']['n_layers'],
+            dense_n_units=raw_data['decoder']['n_units'],
+            dense_activation=raw_data['decoder']['activation'],
+            dense_dropout=raw_data['decoder']['dropout'],
+            dense_init=_gluon_common.INIT_MAP[raw_data['decoder']['init'].lower()],
+            dense_prefix=raw_data['decoder']['prefix'],
+        )

--- a/moleculegen/generation/greedy_search.py
+++ b/moleculegen/generation/greedy_search.py
@@ -13,6 +13,7 @@ __all__ = (
 
 
 import inspect
+import warnings
 from typing import Any, Callable, List
 
 from mxnet import context, np, npx
@@ -86,6 +87,14 @@ class GreedySearch:
             distribution: Callable = _nd_multinomial,
             ctx: Callable = _mxnet_ctx,
     ):
+        warnings.warn(
+            message=(
+                f'{self.__class__.__name__} is deprecated; '
+                f'wil be removed in 1.1.0.'
+                f'consider `moleculegen.generation.SoftmaxSearch` instead.'
+            ),
+            category=DeprecationWarning,
+        )
         if not all(
                 hasattr(obj, '__call__') for obj in (
                     data_type, normalizer, distribution, ctx,

--- a/moleculegen/generation/search.py
+++ b/moleculegen/generation/search.py
@@ -19,7 +19,7 @@ __all__ = (
 
 
 import functools
-from typing import Callable, List
+from typing import Callable, List, Optional
 
 import mxnet as mx
 
@@ -260,14 +260,19 @@ class SoftmaxSearch(BaseSearch):
             prefix: str = Token.BOS,
             max_length: int = 100,
             temperature: float = 1.0,
+            normalizer: Optional[Callable[..., mx.np.ndarray]] = None,
+            distribution: Optional[Callable[..., int]] = None,
     ):
+        normalizer = normalizer or _numpy_softmax
+        distribution = distribution or _multinomial
+
         super().__init__(
             model=model,
             vocabulary=vocabulary,
             prefix=prefix,
             max_length=max_length,
-            normalizer=functools.partial(_numpy_softmax, temperature=temperature),
-            distribution=_multinomial,
+            normalizer=functools.partial(normalizer, temperature=temperature),
+            distribution=distribution,
         )
 
         self.temperature = temperature

--- a/moleculegen/generation/search.py
+++ b/moleculegen/generation/search.py
@@ -1,20 +1,13 @@
 """
 SMILES samplers to generate new molecules using various greedy search methods.
 
-Classes
--------
-BaseSearch
-    The base SMILES sampler class.
-
-ArgmaxSearch
-    Generate new SMILES strings using greedy search (argmax) method.
-
-SoftmaxSearch
-    Softmax with a sensitivity parameter followed by sampling from multinomial
-    distribution.
-GumbelSoftmaxSearch
-    Gumbel-Softmax with a sensitivity parameter followed by sampling from multinomial
-    distribution.
+Classes:
+    BaseSearch: The base SMILES sampler class.
+    ArgmaxSearch: Generate new SMILES strings using greedy search (argmax) method.
+    SoftmaxSearch: Softmax with a sensitivity parameter followed by sampling from
+        multinomial distribution.
+    GumbelSoftmaxSearch: Gumbel-Softmax with a sensitivity parameter followed by sampling
+        from multinomial distribution.
 """
 
 __all__ = (
@@ -26,13 +19,13 @@ __all__ = (
 
 
 import functools
-from typing import Callable, List, Optional
+from typing import Callable, List
 
 import mxnet as mx
 
 from ..base import Token
 from ..data.vocabulary import SMILESVocabulary
-from ..estimation.base import SMILESEncoderDecoderABC
+from ..estimation.base import SMILESLM
 
 
 class BaseSearch:
@@ -40,16 +33,14 @@ class BaseSearch:
 
     Parameters
     ----------
-    model : SMILESEncoderDecoderABC
+    model : moleculegen.estimation.SMILESLM
         A (trained) language model. Generates one token ID in one step.
-    vocabulary : SMILESVocabulary
+    vocabulary : moleculegen.data.SMILESVocabulary
         A SMILES vocabulary. Provides id-to-token conversion.
     prefix : str
         The prefix of a SMILES string to generate.
     max_length : int
         The maximum number of tokens in the SMILES string being generated.
-    state_initializer : callable, any -> mx.nd.NDArray
-        The model's hidden state initializer function (e.g. mx.nd.ones).
     normalizer : callable, any -> mx.np.ndarray
         A function that accepts model's outputs (logits) and returns probabilities.
     distribution : callable, any -> int
@@ -59,14 +50,13 @@ class BaseSearch:
 
     def __init__(
             self,
-            model: SMILESEncoderDecoderABC,
+            model: SMILESLM,
             vocabulary: SMILESVocabulary,
             *,
             prefix: str,
             max_length: int,
-            state_initializer: Callable[..., mx.nd.NDArray],
-            normalizer: Callable,
-            distribution: Callable,
+            normalizer: Callable[..., mx.np.ndarray],
+            distribution: Callable[..., int],
     ):
         self._model = model
         self._vocabulary = vocabulary
@@ -75,7 +65,6 @@ class BaseSearch:
 
         self.prefix = prefix
         self.max_length = max_length
-        self.state_initializer = state_initializer
 
     @property
     def prefix(self) -> str:
@@ -127,7 +116,7 @@ class BaseSearch:
         self.__max_length = max_length
 
     @property
-    def model(self) -> SMILESEncoderDecoderABC:
+    def model(self) -> SMILESLM:
         return self._model
 
     @property
@@ -152,8 +141,12 @@ class BaseSearch:
         -------
         smiles : str
         """
-        # Initialize hidden states.
-        states = self._model.begin_state(batch_size=1, func=self.state_initializer)
+        # If the inherited model class has a hidden state, `empty_state` is
+        # expected to free its content (e.g. set to None) prior to training
+        # and `begin_state` to reinitialize its content.
+        getattr(self._model, 'empty_state', lambda: None)()
+        getattr(self._model, 'begin_state', lambda *a: None)(1)
+
         # Tokenize sequence correctly.
         tokens: List[str] = Token.tokenize(self.prefix)
         # Save predicted token IDs.
@@ -162,19 +155,20 @@ class BaseSearch:
         # Update `states` on prefix tokens (no prediction is made).
         for token in tokens[1:]:
             token_id = self._np_token_data([token_ids[-1]])
-            _, states = self._model(token_id, states)
+            self._model(token_id)
             token_ids.append(self._vocabulary[token])
 
         # Predict the next token IDs.
         for n_iter in range(self.max_length):
-            inputs = self._np_token_data([token_ids[-1]])
-            outputs, states = self._model(inputs, states)
+            inputs = self._np_token_data([token_ids[-1]])  # shape=(1, 1)
+            outputs = self._model(inputs)  # shape=(1, 1, len(self._vocabulary))
 
-            # Normalize outputs to get probabilities (e.g. using softmax).
+            # Normalize outputs to get probabilities (e.g. using softmax);
+            # probabilities.shape == (1, len(self._vocabulary)).
             probabilities: mx.np.ndarray = self._normalizer(outputs[0])
 
             # Sample from a distribution (e.g. multinomial).
-            next_token_id: int = self._distribution(probabilities)
+            next_token_id: int = self._distribution(probabilities[0])
 
             # Interrupt, if End-of-SMILES token is generated.
             token: str = self._vocabulary.idx_to_token[next_token_id]
@@ -205,42 +199,36 @@ class ArgmaxSearch(BaseSearch):
 
     Parameters
     ----------
-    model : SMILESEncoderDecoderABC
+    model : moleculegen.estimation.SMILESLM
         A (trained) language model. Generates one token ID in one step.
-    vocabulary : SMILESVocabulary
+    vocabulary : moleculegen.data.SMILESVocabulary
         A SMILES vocabulary. Provides id-to-token conversion.
-    prefix : str
+    prefix : str, default=moleculegen.Token.BOS
         The prefix of a SMILES string to generate.
-    max_length : int
+    max_length : int, default=100
         The maximum number of tokens in the SMILES string being generated.
-    state_initializer : callable, any -> mx.nd.NDArray
-        The model's hidden state initializer function (e.g. mx.nd.ones).
     """
 
     def __init__(
             self,
-            model: SMILESEncoderDecoderABC,
+            model: SMILESLM,
             vocabulary: SMILESVocabulary,
             *,
             prefix: str = Token.BOS,
-            max_length: int = 80,
-            state_initializer: Callable[..., mx.nd.NDArray] = mx.nd.uniform,
+            max_length: int = 100,
     ):
         super().__init__(
             model=model,
             vocabulary=vocabulary,
             prefix=prefix,
             max_length=max_length,
-            state_initializer=state_initializer,
             normalizer=_identity,
             distribution=_argmax,
         )
 
 
-def _nd_multinomial(probabilities: mx.np.ndarray) -> int:
-    sample = mx.random.multinomial(probabilities.as_nd_ndarray())
-    sample = sample.as_np_ndarray().item()
-    return sample
+def _multinomial(probabilities: mx.np.ndarray) -> int:
+    return mx.random.multinomial(probabilities.as_nd_ndarray()).asscalar()
 
 
 # noinspection PyUnresolvedReferences
@@ -253,43 +241,33 @@ class SoftmaxSearch(BaseSearch):
 
     Parameters
     ----------
-    model : SMILESEncoderDecoderABC
+    model : moleculegen.estimation.SMILESLM
         A (trained) language model. Generates one token ID in one step.
-    vocabulary : SMILESVocabulary
+    vocabulary : moleculegen.data.SMILESVocabulary
         A SMILES vocabulary. Provides id-to-token conversion.
-    prefix : str, default Token.BOS
+    prefix : str, default=moleculegen.Token.BOS
         The prefix of a SMILES string to generate.
-    max_length : int, default 80
+    max_length : int, default=100
         The maximum number of tokens in the SMILES string being generated.
-    temperature : float, default 1.0
+    temperature : float, default=1.0
         A sensitivity parameter.
-    state_initializer : callable, any -> mx.nd.NDArray
-        The model's hidden state initializer function (e.g. mx.nd.ones).
     """
     def __init__(
             self,
-            model: SMILESEncoderDecoderABC,
+            model: SMILESLM,
             vocabulary: SMILESVocabulary,
             *,
             prefix: str = Token.BOS,
-            max_length: int = 80,
+            max_length: int = 100,
             temperature: float = 1.0,
-            state_initializer: Callable[..., mx.nd.NDArray] = mx.nd.zeros,
-            normalizer: Optional[Callable[..., mx.np.ndarray]] = None,
-            distribution: Optional[Callable[..., int]] = None,
     ):
-        normalizer = normalizer or _numpy_softmax
-        distribution = distribution or _nd_multinomial
-        normalizer_part = functools.partial(normalizer, temperature=temperature)
-
         super().__init__(
             model=model,
             vocabulary=vocabulary,
             prefix=prefix,
             max_length=max_length,
-            state_initializer=state_initializer,
-            normalizer=normalizer_part,
-            distribution=distribution,
+            normalizer=functools.partial(_numpy_softmax, temperature=temperature),
+            distribution=_multinomial,
         )
 
         self.temperature = temperature
@@ -334,41 +312,32 @@ class GumbelSoftmaxSearch(SoftmaxSearch):
 
     Parameters
     ----------
-    model : SMILESEncoderDecoderABC
+    model : moleculegen.estimation.SMILESLM
         A (trained) language model. Generates one token ID in one step.
-    vocabulary : SMILESVocabulary
+    vocabulary : moleculegen.dataSMILESVocabulary
         A SMILES vocabulary. Provides id-to-token conversion.
-    prefix : str, default Token.BOS
+    prefix : str, default=moleculegen.Token.BOS
         The prefix of a SMILES string to generate.
-    max_length : int, default 80
+    max_length : int, default=100
         The maximum number of tokens in the SMILES string being generated.
-    temperature : float, default 1.0
+    temperature : float, default=1.0
         A sensitivity parameter.
-    state_initializer : callable, any -> mx.nd.NDArray
-        The model's hidden state initializer function (e.g. mx.nd.ones).
     """
 
     def __init__(
             self,
-            model: SMILESEncoderDecoderABC,
+            model: SMILESLM,
             vocabulary: SMILESVocabulary,
             *,
             prefix: str = Token.BOS,
-            max_length: int = 80,
+            max_length: int = 100,
             temperature: float = 1.0,
-            state_initializer: Callable[..., mx.nd.NDArray] = mx.nd.zeros,
-            normalizer: Optional[Callable[..., mx.np.ndarray]] = None,
-            distribution: Optional[Callable[..., int]] = None,
     ):
-        normalizer = normalizer or _gumbel_trick
-
         super().__init__(
             model=model,
             vocabulary=vocabulary,
             prefix=prefix,
             max_length=max_length,
             temperature=temperature,
-            state_initializer=state_initializer,
-            normalizer=normalizer,
-            distribution=distribution,
+            normalizer=_gumbel_trick,
         )

--- a/tests/test_callback.py
+++ b/tests/test_callback.py
@@ -23,6 +23,8 @@ class ProgressBarTestCase(unittest.TestCase):
         n_batches = 40
         batch_sampler = list(range(n_batches))
 
+        callback.on_train_begin(batch_sampler=batch_sampler)
+
         for epoch in range(1, n_epochs + 1):
             callback.on_epoch_begin(
                 batch_sampler=batch_sampler, n_epochs=n_epochs, epoch=epoch)
@@ -35,6 +37,8 @@ class ProgressBarTestCase(unittest.TestCase):
                 callback.on_batch_end(loss=loss, batch_no=batch_no)
 
             callback.on_epoch_end()
+
+        callback.on_train_end()
 
 
 if __name__ == '__main__':

--- a/tests/test_generation.py
+++ b/tests/test_generation.py
@@ -11,43 +11,9 @@ from moleculegen.data import (
     SMILESDataset,
     SMILESVocabulary,
 )
-from moleculegen.estimation import SMILESEncoderDecoder
-from moleculegen.generation import GreedySearch
+from moleculegen.estimation import SMILESRNN
 from moleculegen.generation.search import SoftmaxSearch, ArgmaxSearch
 from .utils import TempSMILESFile
-
-
-class GreedySearchTestCase(unittest.TestCase):
-    def setUp(self):
-        temp_file = TempSMILESFile(
-            tempfile_kwargs={'prefix': 'greedy_search'})
-        self.fh = temp_file.open()
-
-        dataset = SMILESDataset(self.fh.name)
-        self.vocabulary = SMILESVocabulary(dataset, need_corpus=True)
-
-        self.model = SMILESEncoderDecoder(len(self.vocabulary))
-
-        self.predictor = GreedySearch()
-
-    def test_call(self):
-        self.model.initialize()
-        states = self.model.begin_state(batch_size=1)
-
-        valid_tokens = Token.get_all_tokens() - frozenset(Token.UNK)
-
-        for _ in range(100):
-
-            smiles = self.predictor(self.model, states, self.vocabulary)
-
-            for token in Token.tokenize(smiles):
-                if len(token) == 1 and token.islower():
-                    token = token.upper()
-
-                self.assertIn(token, valid_tokens)
-
-    def tearDown(self):
-        self.fh.close()
 
 
 class ArgmaxSearchTestCase(unittest.TestCase):
@@ -58,7 +24,7 @@ class ArgmaxSearchTestCase(unittest.TestCase):
         dataset = SMILESDataset(self.fh.name)
         self.vocabulary = SMILESVocabulary(dataset, need_corpus=True)
 
-        self.model = SMILESEncoderDecoder(len(self.vocabulary))
+        self.model = SMILESRNN(len(self.vocabulary))
 
         self.predictor = ArgmaxSearch(self.model, self.vocabulary)
 
@@ -84,7 +50,7 @@ class ArgmaxSearchTestCase(unittest.TestCase):
         self.fh.close()
 
 
-class SoftmaxSamplerTestCase(unittest.TestCase):
+class SoftmaxSearchTestCase(unittest.TestCase):
     def setUp(self):
         temp_file = TempSMILESFile(tempfile_kwargs={'prefix': 'softmax_sampler'})
         self.fh = temp_file.open()
@@ -92,7 +58,7 @@ class SoftmaxSamplerTestCase(unittest.TestCase):
         dataset = SMILESDataset(self.fh.name)
         self.vocabulary = SMILESVocabulary(dataset, need_corpus=True)
 
-        self.model = SMILESEncoderDecoder(len(self.vocabulary))
+        self.model = SMILESRNN(len(self.vocabulary))
 
         self.predictor = SoftmaxSearch(self.model, self.vocabulary)
 


### PR DESCRIPTION
Resolves #44 

* Refactor `moleculegen.data.sampler` (beb4e7d27f4d23898b3f81880853114bedafb712).
* CPU or GPU can be specified in form `'ctx_name:ctx_id1:...:ctx_idn'`, e.g. `'gpu:1'` (dfcb604).
* Adapt samplers from `moleculegen.generation` to a new `moleculegen.estimation.SMILESLM` API (a97080d).