### PR TITLE
Fix minor bugs

### DIFF
--- a/moleculegen/data/sampler.py
+++ b/moleculegen/data/sampler.py
@@ -536,6 +536,10 @@ class SMILESConsecutiveSampler(mx.gluon.data.Sampler):
             shuffle: bool = True,
             max_offset: int = 0,
     ):
+        assert max_offset == 0 or max_offset + 2 <= min(map(len, corpus)), \
+            "`max_offset` is greater than one of the sequences in `corpus` and " \
+            "does not save at least one token each for input and output"
+
         self._corpus = corpus
         self._shuffle = shuffle
         self._n_steps = n_steps or max(map(len, self._corpus))

--- a/moleculegen/evaluation/metric.py
+++ b/moleculegen/evaluation/metric.py
@@ -157,6 +157,12 @@ class CompositeMetric:
         if metrics:
             self.add(*metrics)
 
+    def __repr__(self) -> str:
+        repr_str = f'{self.__class__.__name__}(\n\t'
+        repr_str += ',\n\t'.join(map(repr, self._metrics))
+        repr_str += ',\n)'
+        return repr_str
+
     def __getitem__(self, index: int) -> Metric:
         """Return the metric with index `index`.
 
@@ -646,7 +652,7 @@ class InternalDiversity(Metric):
             radius: int = 2,
             n_bits: int = 1024,
             dtype: str = 'float32',
-            name: Optional[str] = 'IndDiv',
+            name: Optional[str] = 'IntDiv',
             empty_value: Any = float('nan'),
     ):
         super().__init__(name=name, empty_value=empty_value)


### PR DESCRIPTION
* `moleculegen.data.SMILESConsecutiveSampler` and `SMILESRandomSampler` require `max_offset` to be the minimum number of tokens in `corpus` `+ 2` (48fca26).
* `repr(moleculegen.evaluation.CompositeMetric)` prints compact metric list (6db0908).
* `moleculegen.callback.EpochMetricScorer` generates a tuple of strings if `moleculegen.evaluation.InternalDiversity`, `KLDivergence`, or `NearestNeighborSimilarity` presented (032c1ac).