### PR TITLE
Extend initializer options

### DIFF
--- a/moleculegen/_types.py
+++ b/moleculegen/_types.py
@@ -13,7 +13,9 @@ ActivationT = Union[
 
 ContextT = Union[context.Context, List[context.Context]]
 
-Initializers = Literal['uniform', 'normal', 'orthogonal', 'xavier']
+Initializers = Literal[
+    'uniform', 'normal', 'orthogonal_uniform', 'orthogonal_normal',
+    'xavier_uniform', 'xavier_normal']
 InitializerT = Union[None, Initializers, init.Initializer]
 
 Optimizers = Literal[

--- a/moleculegen/estimation/_gluon_common.py
+++ b/moleculegen/estimation/_gluon_common.py
@@ -19,9 +19,11 @@ RNN_MAP: Dict[str, type] = {
 
 INIT_MAP: Dict[str, mx.init.Initializer] = {
     'normal': mx.init.Normal(),
-    'orthogonal': mx.init.Orthogonal(),
     'uniform': mx.init.Uniform(),
-    'xavier': mx.init.Xavier(),
+    'orthogonal_uniform': mx.init.Orthogonal(rand_type='uniform'),
+    'orthogonal_normal': mx.init.Orthogonal(rand_type='normal'),
+    'xavier_uniform': mx.init.Xavier(rnd_type='uniform'),
+    'xavier_normal': mx.init.Xavier(rnd_type='gaussian')
 }
 
 

--- a/moleculegen/estimation/base.py
+++ b/moleculegen/estimation/base.py
@@ -21,6 +21,7 @@ from typing import Callable, List, Optional, Sequence, TextIO, Tuple
 import mxnet as mx
 from mxnet import autograd, gluon
 
+from . import _gluon_common
 from ..callback.base import Callback, CallbackList
 from ..data.sampler import SMILESBatchSampler
 from ..evaluation.loss import get_mask_for_loss
@@ -291,7 +292,7 @@ class SMILESLM(mx.gluon.Block, metaclass=abc.ABCMeta):
     ):
         super().__init__(prefix=prefix, params=params)
 
-        self.__ctx = ctx or mx.context.cpu()
+        self.__ctx = _gluon_common.get_ctx(ctx)
 
     @property
     @abc.abstractmethod

--- a/moleculegen/estimation/base.py
+++ b/moleculegen/estimation/base.py
@@ -1,10 +1,8 @@
 """
 The base class for generative language models.
 
-Classes
--------
-SMILESEncoderDecoderABC
-    An ABC for a generative recurrent neural network to encode-decode SMILES strings.
+Classes:
+    SMILESLM: An ABC for generative language models.
 """
 
 __all__ = (
@@ -457,7 +455,7 @@ class SMILESLM(mx.gluon.Block, metaclass=abc.ABCMeta):
             cls,
             path: str,
             update_features: bool = False,
-            decoder_init: InitializerT = mx.init.Xavier(),
+            decoder_init: InitializerT = 'xavier_uniform',
     ) -> 'SMILESLM':
         """Create a new fine-tuner model: load model configuration and parameters, and
         initialize decoder weights.
@@ -470,23 +468,25 @@ class SMILESLM(mx.gluon.Block, metaclass=abc.ABCMeta):
             path/weights.params - the parameters of a model.
         update_features : bool, default=False
             Whether to update embedding and encoder parameters during training.
-        decoder_init : {'uniform', 'normal', 'orthogonal', 'xavier'}
+        decoder_init : {'uniform', 'normal', 'orthogonal_uniform', 'orthogonal_normal',
+                'xavier_uniform', 'xavier_normal'},
                 or mxnet.init.Initializer or None,
-                default=mxnet.init.Xavier()
+                default='xavier_uniform'
             The parameter initializer of a dense layer.
 
         Returns
         -------
         model : SMILESLM
         """
-        model = cls.from_config(f'{path}/config.json')
-        model.load_parameters(f'{path}/weights.params', ctx=model.ctx)
+        model = cls.from_config(f'{path.rstrip("/")}/config.json')
+        model.load_parameters(f'{path.rstrip("/")}/weights.params', ctx=model.ctx)
 
         if not update_features:
             model.embedding.collect_params().setattr('grad_req', 'null')
             model.encoder.collect_params().setattr('grad_req', 'null')
 
-        model.decoder.initialize(init=decoder_init, force_reinit=True, ctx=model.ctx)
+        model.decoder.initialize(
+            init=_gluon_common.get_init(decoder_init), force_reinit=True, ctx=model.ctx)
 
         return model
 

--- a/moleculegen/estimation/rnn.py
+++ b/moleculegen/estimation/rnn.py
@@ -10,7 +10,7 @@ __all__ = (
 )
 
 import json
-from typing import Callable, List, Literal, Optional, Union
+from typing import Callable, List, Literal, Optional, Tuple, Union
 
 import mxnet as mx
 
@@ -34,9 +34,13 @@ class SMILESRNN(SMILESLM):
         The output dimension of an embedding layer.
     embedding_dropout : float, default=0.4
         The dropout rate of an embedding layer.
-    embedding_init : {'uniform', 'normal', 'orthogonal', 'xavier'}
+    embedding_dropout_axes : int or tuple of int, default=1
+        Whether to drop out entire feature column (1), entire token column (2), or
+        token-feature entries selectively (0).
+    embedding_init : {'uniform', 'normal', 'orthogonal_uniform', 'orthogonal_normal',
+            'xavier_uniform', 'xavier_normal'},
             or mxnet.init.Initializer or None,
-            default=mxnet.init.Uniform()
+            default='xavier_uniform'
         The parameter initializer of an embedding layer.
     embedding_prefix : str, default='embedding_'
         The prefix of an embedding block.
@@ -48,10 +52,16 @@ class SMILESRNN(SMILESLM):
         The number of neurons in an RNN.
     rnn_dropout : float, default=0.6
         The dropout rate of a recurrent layer.
-    rnn_init : {'uniform', 'normal', 'orthogonal', 'xavier'}
+    rnn_i2h_init : {'uniform', 'normal', 'orthogonal_uniform', 'orthogonal_normal',
+            'xavier_uniform', 'xavier_normal'},
             or mxnet.init.Initializer or None,
-            default=mxnet.init.Orthogonal()
-        The parameter initializer of a recurrent layer.
+            default='xavier_uniform'
+        The input-to-hidden parameter initializer of a recurrent layer.
+    rnn_h2h_init : {'uniform', 'normal', 'orthogonal_uniform', 'orthogonal_normal',
+            'xavier_uniform', 'xavier_normal'},
+            or mxnet.init.Initializer or None,
+            default='orthogonal_normal'
+        The hidden-to-hidden parameter initializer of a recurrent layer.
     rnn_prefix : str, default='encoder_'
         The prefix of an encoder block.
     rnn_state_init : callable, any -> mxnet.nd.NDArray, default=mxnet.nd.zeros
@@ -73,9 +83,10 @@ class SMILESRNN(SMILESLM):
         The activation function in a dense layer.
     dense_dropout : float, default=0.5
         The dropout rate of a dense layer.
-    dense_init : {'uniform', 'normal', 'orthogonal', 'xavier'}
+    dense_init : {'uniform', 'normal', 'orthogonal_uniform', 'orthogonal_normal',
+            'xavier_uniform', 'xavier_normal'},
             or mxnet.init.Initializer or None,
-            default=mxnet.init.Xavier()
+            default='xavier_uniform'
         The parameter initializer of a dense layer.
     dense_prefix : str, default='decoder_'
         The prefix of a decoder block.
@@ -126,14 +137,16 @@ class SMILESRNN(SMILESLM):
             use_one_hot: bool = False,
             embedding_dim: int = 32,
             embedding_dropout: float = 0.4,
-            embedding_init: InitializerT = mx.init.Uniform(),
+            embedding_dropout_axes: Union[int, Tuple[int]] = 1,
+            embedding_init: InitializerT = 'xavier_uniform',
             embedding_prefix: str = 'embedding_',
 
             rnn: Literal['lstm', 'gru', 'vanilla'] = 'lstm',
             rnn_n_layers: int = 2,
             rnn_n_units: int = 256,
             rnn_dropout: float = 0.6,
-            rnn_init: InitializerT = mx.init.Orthogonal(),
+            rnn_i2h_init: InitializerT = 'xavier_uniform',
+            rnn_h2h_init: InitializerT = 'orthogonal_normal',
             rnn_prefix: str = 'encoder_',
             rnn_state_init: Callable[..., mx.nd.NDArray] = mx.nd.zeros,
             rnn_reinit_state: bool = False,
@@ -143,7 +156,7 @@ class SMILESRNN(SMILESLM):
             dense_n_units: Union[int, List[int]] = 128,
             dense_activation: Union[ActivationT, List[ActivationT]] = 'relu',
             dense_dropout: Union[float, List[float]] = 0.5,
-            dense_init: InitializerT = mx.init.Xavier(),
+            dense_init: InitializerT = 'xavier_uniform',
             dense_prefix: str = 'decoder_',
 
             tie_weights: bool = False,
@@ -180,31 +193,30 @@ class SMILESRNN(SMILESLM):
                     output_dim=embedding_dim,
                     dtype=dtype,
                     prefix=embedding_prefix,
+                    weight_initializer=_gluon_common.get_init(embedding_init),
                 )
 
                 if embedding_dropout != 0.:
                     seq_prefix = f'{embedding_prefix.rstrip("_")}seq_'
                     self._embedding = mx.gluon.nn.HybridSequential(prefix=seq_prefix)
                     self._embedding.add(embedding_block)
-                    self._embedding.add(mx.gluon.nn.Dropout(embedding_dropout, axes=1))
+                    self._embedding.add(mx.gluon.nn.Dropout(
+                        embedding_dropout, axes=embedding_dropout_axes))
                     shared_params = self._embedding[0].params if tie_weights else None
                 else:
                     self._embedding = embedding_block
                     shared_params = self._embedding.params if tie_weights else None
-
-                if initialize:
-                    self._embedding.initialize(init=embedding_init, ctx=ctx)
 
             # Select (and initialize) a recurrent block.
             self._encoder = _gluon_common.RNN_MAP[rnn](
                 hidden_size=rnn_n_units,
                 num_layers=rnn_n_layers,
                 dropout=rnn_dropout,
+                i2h_weight_initializer=_gluon_common.get_init(rnn_i2h_init),
+                h2h_weight_initializer=_gluon_common.get_init(rnn_h2h_init),
                 dtype=dtype,
                 prefix=rnn_prefix,
             )
-            if initialize:
-                self._encoder.initialize(init=rnn_init, ctx=ctx)
 
             # Define (and initialize) a dense (sequential) block.
             self._decoder = _gluon_common.mlp(
@@ -214,12 +226,13 @@ class SMILESRNN(SMILESLM):
                 output_dim=vocab_size,
                 dtype=dtype,
                 dropout=dense_dropout,
+                init=_gluon_common.get_init(dense_init),
                 prefix=dense_prefix,
                 params=shared_params,
             )
+
             if initialize:
-                self._decoder.initialize(
-                    force_reinit=tie_weights, init=dense_init, ctx=ctx)
+                self.initialize(ctx=self.ctx)
 
         self._state: Optional[List[mx.np.ndarray]] = None
         self.state_initializer: Callable[..., mx.nd.NDArray] = rnn_state_init

--- a/tests/test_estimation.py
+++ b/tests/test_estimation.py
@@ -35,19 +35,32 @@ class SMILESRNNTestCase(unittest.TestCase):
 
         self.model = SMILESRNN(
             len(self.vocabulary),
+
             use_one_hot=False,
             embedding_dim=4,
             embedding_dropout=0.25,
-            embedding_init=mx.init.Orthogonal(),
+            embedding_dropout_axes=0,
+            embedding_init=mx.init.Uniform(),
+            embedding_prefix='embedding_',
+
             rnn='lstm',
             rnn_n_layers=self.n_rnn_layers,
             rnn_n_units=self.n_rnn_units,
+            rnn_i2h_init='xavier_normal',
+            rnn_h2h_init='orthogonal_normal',
+            rnn_reinit_state=True,
+            rnn_detach_state=False,
+            rnn_state_init=mx.nd.random.uniform,
             rnn_dropout=0.0,
-            rnn_init=mx.init.Normal(),
-            dense_n_layers=1,
+            rnn_prefix='encoder_',
+
+            dense_n_layers=2,
+            dense_n_units=32,
             dense_activation='relu',
             dense_dropout=0.5,
             dense_init=mx.init.Xavier(),
+            dense_prefix='decoder_',
+
             dtype='float32',
             prefix='model_'
         )
@@ -59,7 +72,8 @@ class SMILESRNNTestCase(unittest.TestCase):
             'model_encoder_l0_i2h_weight', 'model_encoder_l0_h2h_weight',
             'model_encoder_l0_i2h_bias', 'model_encoder_l0_h2h_bias',
 
-            'model_decoder_weight', 'model_decoder_bias',
+            'model_decoder_l0_weight', 'model_decoder_l0_bias',
+            'model_decoder_out_weight', 'model_decoder_out_bias',
         )
 
         for actual_p, test_p in zip(param_names, self.model.collect_params()):


### PR DESCRIPTION
See #31 
- [x] Add Gaussian Xavier and Gaussian Orthogonal initializers.
- [x] `moleculegen.estimation.SMILESRNN` has separate input-to-hidden and hidden-to-hidden initializers.